### PR TITLE
Correct ncped 'off-by-1' def. errors from ln. 51207 onwards

### DIFF
--- a/dictionaries/en/ncped.json
+++ b/dictionaries/en/ncped.json
@@ -51205,711 +51205,711 @@
     },
     {
         "word": "niṭṭhā",
-        "text": "<dl id='niṭṭhā'><dt><dfn>niṭṭhā</dfn></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>completion; culminating point; end, object, aim.</li><li>death.</li></ol></li><li>certain knowledge, decision, conclusion; <i>~aṃ gacchati</i>, is decided, is certain; knows; concludes, is convinced; ( <i>~aṃ gata</i> is often written <i>niṭṭhaṅgata</i>, or occasionally there is <i>niṭṭhāgata</i>) reaches completion; achieves its aim or culminating point.</li></ol></dd></dl>"
+        "text": "<dl id='niṭṭhā'><dt><dfn>niṭṭhā</dfn><sup>1</sup></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li>completion; culminating point; end, object, aim.</li><li>death.</li></ol></dd><dt><dfn>niṭṭhā</dfn><sup>2</sup></dt><dd><p>certain knowledge, decision, conclusion.</p></dd></dl>"
     },
     {
         "word": "niṭṭhām gaccathi",
-        "text": "<dl id='niṭṭhām gaccathi'><dt><dfn>niṭṭhām gaccathi</dfn></dt><dd><p>decided, certain, convinced.</p></dd></dl>"
+        "text": "<dl id='niṭṭhām gaccathi'><dt><dfn>niṭṭhām gaccathi</dfn></dt><dd><p>is decided, is certain; knows; concludes, is convinced; ( <i>~aṃ gata</i> is often written <i>niṭṭhaṅgata</i>, or occasionally there is <i>niṭṭhāgata</i>) reaches completion; achieves its aim or culminating point.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāgata",
-        "text": "<dl id='niṭṭhāgata'><dt><dfn>niṭṭhāgata</dfn></dt><dd><p><span class='case'>mfn.</span> decided, certain, convinced.</p></dd></dl>"
+        "text": "<dl id='niṭṭhāgata'><dt><dfn>niṭṭhāgata</dfn></dt><dd><p>decided, certain, convinced.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāṅgata",
-        "text": "<dl id='niṭṭhāṅgata'><dt><dfn>niṭṭhāṅgata</dfn></dt><dd><p><span class='case'>mfn.</span> is finished, comes to an end; is completed; reaches completion.</p></dd></dl>"
+        "text": "<dl id='niṭṭhāṅgata'><dt><dfn>niṭṭhāṅgata</dfn></dt><dd><p><span class='case'>mfn.</span> decided, certain, convinced.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāti",
-        "text": "<dl id='niṭṭhāti'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (from niṭṭhāti) completion, culmination; being finished.</p></dd></dl>"
+        "text": "<dl id='niṭṭhāti'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāti</dfn></dt><dd><p><span class='case'>mfn.</span> is finished, comes to an end; is completed; reaches completion.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāna",
-        "text": "<dl id='niṭṭhāna'><dt><dfn>niṭṭhāna</dfn></dt><dd><p><span class='case'>neuter</span> defined by completion.</p></dd></dl>"
+        "text": "<dl id='niṭṭhāna'><dt><dfn>niṭṭhāna</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (from niṭṭhāti) completion, culmination; being finished.</p></dd></dl>"
     },
     {
         "word": "niṭṭhānantika",
-        "text": "<dl id='niṭṭhānantika'><dt><dfn>niṭṭhānantika</dfn></dt><dd><p><span class='case'>mfn.</span> having caused to accomplish; having caused to finish; having caused to carry out.</p></dd></dl>"
+        "text": "<dl id='niṭṭhānantika'><dt><dfn>niṭṭhānantika</dfn></dt><dd><p><span class='case'>neuter</span> defined by completion.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāpetvā",
-        "text": "<dl id='niṭṭhāpetvā'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāpetvā</dfn></dt><dd><p><span class='case'>absol.</span> caused to accomplish; caused to finish; caused to carry out.</p></dd></dl>"
+        "text": "<dl id='niṭṭhāpetvā'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāpetvā</dfn></dt><dd><p><span class='case'>mfn.</span> having caused to accomplish; having caused to finish; having caused to carry out.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāpesi",
-        "text": "<dl id='niṭṭhāpesi'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāpesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/niṭṭhāti'>niṭṭhāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhāpesi'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhāpesi</dfn></dt><dd><p><span class='case'>absol.</span> caused to accomplish; caused to finish; caused to carry out.</p></dd></dl>"
     },
     {
         "word": "niṭṭhāyati",
-        "text": "<dl id='niṭṭhāyati'><dt><dfn>niṭṭhāyati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhāti</span> brought or come to an end, finished, completed; ready (see <i><a href='/define/niṭṭhāti'>niṭṭhāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhāyati'><dt><dfn>niṭṭhāyati</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/niṭṭhāti'>niṭṭhāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niṭṭhita",
-        "text": "<dl id='niṭṭhita'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhita</dfn></dt><dd><p><span class='case'>pp mfn.</span> spits; spits out.</p></dd></dl>"
+        "text": "<dl id='niṭṭhita'><dt data-main-entry='niṭṭhāti'><dfn>niṭṭhita</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhāti</span> brought or come to an end, finished, completed; ready (see <i><a href='/define/niṭṭhāti'>niṭṭhāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niṭṭhubhati",
-        "text": "<dl id='niṭṭhubhati'><dt data-main-entry='niṭṭhubhati'><dfn>niṭṭhubhati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhubhati'><dt data-main-entry='niṭṭhubhati'><dfn>niṭṭhubhati</dfn></dt><dd><p><span class='case'>pp mfn.</span> spits; spits out.</p></dd></dl>"
     },
     {
         "word": "niṭṭhubhitabba",
-        "text": "<dl id='niṭṭhubhitabba'><dt><dfn>niṭṭhubhitabba</dfn></dt><dd><p><span class='case'>fpp n. impers. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhubhitabba'><dt><dfn>niṭṭhubhitabba</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niṭṭhubhitvā",
-        "text": "<dl id='niṭṭhubhitvā'><dt data-main-entry='niṭṭhubhati'><dfn>niṭṭhubhitvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhubhitvā'><dt data-main-entry='niṭṭhubhati'><dfn>niṭṭhubhitvā</dfn></dt><dd><p><span class='case'>fpp n. impers. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niṭṭhuhati",
-        "text": "<dl id='niṭṭhuhati'><dt><dfn>niṭṭhuhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niddāpetabba'>niddāpetabba</a></i>)</p></dd></dl>"
+        "text": "<dl id='niṭṭhuhati'><dt><dfn>niṭṭhuhati</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niḍḍāpetabba",
-        "text": "<dl id='niḍḍāpetabba'><dt><dfn>niḍḍāpetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/niddāyitabba'>niddāyitabba</a></i>)</p></dd></dl>"
+        "text": "<dl id='niḍḍāpetabba'><dt><dfn>niḍḍāpetabba</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niddāpetabba'>niddāpetabba</a></i>)</p></dd></dl>"
     },
     {
         "word": "niḍḍāyitabba",
-        "text": "<dl id='niḍḍāyitabba'><dt><dfn>niḍḍāyitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nitthiṇṇa'>nitthiṇṇa</a></i>)</p></dd></dl>"
+        "text": "<dl id='niḍḍāyitabba'><dt><dfn>niḍḍāyitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/niddāyitabba'>niddāyitabba</a></i>)</p></dd></dl>"
     },
     {
         "word": "nitiṇṇa",
-        "text": "<dl id='nitiṇṇa'><dt><dfn>nitiṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nitthiṇṇa'>nitthiṇṇa</a></i>)</p></dd></dl>"
+        "text": "<dl id='nitiṇṇa'><dt><dfn>nitiṇṇa</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nitthiṇṇa'>nitthiṇṇa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nittiṇṇa",
-        "text": "<dl id='nittiṇṇa'><dt data-main-entry='nittharati'><dfn>nittiṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nitthiṇṇa-ogha'>nitthiṇṇa-ogha</a></i>)</p></dd></dl>"
+        "text": "<dl id='nittiṇṇa'><dt data-main-entry='nittharati'><dfn>nittiṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nitthiṇṇa'>nitthiṇṇa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nittiṇṇa-ogha",
-        "text": "<dl id='nittiṇṇa-ogha'><dt><dfn>nittiṇṇa-ogha</dfn></dt><dd><p><span class='case'>mfn.</span> free from craving.</p></dd></dl>"
+        "text": "<dl id='nittiṇṇa-ogha'><dt><dfn>nittiṇṇa-ogha</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nitthiṇṇa-ogha'>nitthiṇṇa-ogha</a></i>)</p></dd></dl>"
     },
     {
         "word": "nittaṇha",
-        "text": "<dl id='nittaṇha'><dt><dfn>nittaṇha</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nitthunanta'>nitthunanta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nittaṇha'><dt><dfn>nittaṇha</dfn></dt><dd><p><span class='case'>mfn.</span> free from craving.</p></dd></dl>"
     },
     {
         "word": "nitthananta",
-        "text": "<dl id='nitthananta'><dt><dfn>nitthananta</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span></p><ol type='1' class='decimal'><li>getting across; escape from; finishing.</li><li>carrying out; accomplishing, dealing with.</li></ol></dd></dl>"
+        "text": "<dl id='nitthananta'><dt><dfn>nitthananta</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nitthunanta'>nitthunanta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nittharaṇa",
-        "text": "<dl id='nittharaṇa'><dt><dfn>nittharaṇa</dfn></dt><dd><p><span class='case'>n., ~ā, feminine</span> crosses over; gets out of, escapes; expiates.</p></dd></dl>"
+        "text": "<dl id='nittharaṇa'><dt><dfn>nittharaṇa</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span></p><ol type='1' class='decimal'><li>getting across; escape from; finishing.</li><li>carrying out; accomplishing, dealing with.</li></ol></dd></dl>"
     },
     {
         "word": "nittharati",
-        "text": "<dl id='nittharati'><dt data-main-entry='nittharati'><dfn>nittharati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nittharati</span> (see <i><a href='/define/nittharati'>nittharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nittharati'><dt data-main-entry='nittharati'><dfn>nittharati</dfn></dt><dd><p><span class='case'>n., ~ā, feminine</span> crosses over; gets out of, escapes; expiates.</p></dd></dl>"
     },
     {
         "word": "nitthariṃsu",
-        "text": "<dl id='nitthariṃsu'><dt><dfn>nitthariṃsu</dfn></dt><dd><p><span class='case'>aor. 3 pl.</span> (see <i><a href='/define/netthāra'>netthāra</a></i>)</p></dd></dl>"
+        "text": "<dl id='nitthariṃsu'><dt><dfn>nitthariṃsu</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nittharati</span> (see <i><a href='/define/nittharati'>nittharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nitthāra",
-        "text": "<dl id='nitthāra'><dt><dfn>nitthāra</dfn></dt><dd><p><span class='case'>masculine</span> who has crossed; who has got out of, escaped (see <i><a href='/define/nittharati'>nittharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nitthāra'><dt><dfn>nitthāra</dfn></dt><dd><p><span class='case'>aor. 3 pl.</span> (see <i><a href='/define/netthāra'>netthāra</a></i>)</p></dd></dl>"
     },
     {
         "word": "nitthiṇṇa",
-        "text": "<dl id='nitthiṇṇa'><dt><dfn>nitthiṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> who has crossed the torrent or flood.</p></dd></dl>"
+        "text": "<dl id='nitthiṇṇa'><dt><dfn>nitthiṇṇa</dfn></dt><dd><p><span class='case'>masculine</span> who has crossed; who has got out of, escaped (see <i><a href='/define/nittharati'>nittharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nitthiṇṇa-ogha",
-        "text": "<dl id='nitthiṇṇa-ogha'><dt><dfn>nitthiṇṇa-ogha</dfn></dt><dd><p><span class='case'>mfn.</span> who has crossed the torrent or flood.</p></dd></dl>"
+        "text": "<dl id='nitthiṇṇa-ogha'><dt><dfn>nitthiṇṇa-ogha</dfn></dt><dd><p><span class='case'>pp mfn.</span> who has crossed the torrent or flood.</p></dd></dl>"
     },
     {
         "word": "nitthiṇṇogha",
-        "text": "<dl id='nitthiṇṇogha'><dt><dfn>nitthiṇṇogha</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nitthiṇṇa-ogha'>nitthiṇṇa-ogha</a></i>)</p></dd></dl>"
+        "text": "<dl id='nitthiṇṇogha'><dt><dfn>nitthiṇṇogha</dfn></dt><dd><p><span class='case'>mfn.</span> who has crossed the torrent or flood.</p></dd></dl>"
     },
     {
         "word": "nitthuna",
-        "text": "<dl id='nitthuna'><dt><dfn>nitthuna</dfn></dt><dd><p><span class='case'>masculine</span> moaning; groaning.</p></dd></dl>"
+        "text": "<dl id='nitthuna'><dt><dfn>nitthuna</dfn></dt><dd><p><span class='case'>m.</span> groaning</p></dd></dl>"
     },
     {
         "word": "nitthunanta",
-        "text": "<dl id='nitthunanta'><dt data-main-entry='nitthunāti'><dfn>nitthunanta</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nitthunanta'><dt data-main-entry='nitthunāti'><dfn>nitthunanta</dfn></dt><dd><p><span class='case'>masculine</span> moaning; groaning.</p></dd></dl>"
     },
     {
         "word": "nidaṃsayati",
-        "text": "<dl id='nidaṃsayati'><dt><dfn>nidaṃsayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidasseti</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidaṃsayati'><dt><dfn>nidaṃsayati</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidaṃsayi",
-        "text": "<dl id='nidaṃsayi'><dt><dfn>nidaṃsayi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidaṃsayi'><dt><dfn>nidaṃsayi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidasseti</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidaṃseti",
-        "text": "<dl id='nidaṃseti'><dt><dfn>nidaṃseti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>showing; indicating.</li><li>an example, an illustration; evidence; a comparison.</li></ol></dd></dl>"
+        "text": "<dl id='nidaṃseti'><dt><dfn>nidaṃseti</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidassana",
-        "text": "<dl id='nidassana'><dt><dfn>nidassana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidassana'><dt><dfn>nidassana</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>showing; indicating.</li><li>an example, an illustration; evidence; a comparison.</li></ol></dd></dl>"
     },
     {
         "word": "nidassayati",
-        "text": "<dl id='nidassayati'><dt><dfn>nidassayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidasseti</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidassayati'><dt><dfn>nidassayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidassayi",
-        "text": "<dl id='nidassayi'><dt><dfn>nidassayi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> shows; points out; teaches, instructs.</p></dd></dl>"
+        "text": "<dl id='nidassayi'><dt><dfn>nidassayi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidasseti</span> (see <i><a href='/define/nidasseti'>nidasseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidasseti",
-        "text": "<dl id='nidasseti'><dt data-main-entry='nidasseti'><dfn>nidasseti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> puts or lays by; deposits, stores, keeps; buries.</p></dd></dl>"
+        "text": "<dl id='nidasseti'><dt data-main-entry='nidasseti'><dfn>nidasseti</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> shows; points out; teaches, instructs.</p></dd></dl>"
     },
     {
         "word": "nidahati",
-        "text": "<dl id='nidahati'><dt data-main-entry='nidahati'><dfn>nidahati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidahita</span> (see <i><a href='/define/nidahita'>nidahita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidahati'><dt data-main-entry='nidahati'><dfn>nidahati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> puts or lays by; deposits, stores, keeps; buries.</p></dd></dl>"
     },
     {
         "word": "nidahitabba",
-        "text": "<dl id='nidahitabba'><dt><dfn>nidahitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidahitabba'><dt><dfn>nidahitabba</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nidahita</span> (see <i><a href='/define/nidahita'>nidahita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidahitvā",
-        "text": "<dl id='nidahitvā'><dt data-main-entry='nidahati'><dfn>nidahitvā</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>cause, ground, underlying and determining factor; antecedent: occasion.</li><li>preamble; introduction (giving occasion, setting, context)</li></ol></dd></dl>"
+        "text": "<dl id='nidahitvā'><dt data-main-entry='nidahati'><dfn>nidahitvā</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidāna",
-        "text": "<dl id='nidāna'><dt><dfn>nidāna</dfn></dt><dd><p><span class='case'>neuter</span> free from fever; free from distress (see <i><a href='/define/dara'>dara</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidāna'><dt><dfn>nidāna</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>cause, ground, underlying and determining factor; antecedent: occasion.</li><li>preamble; introduction (giving occasion, setting, context)</li></ol></dd></dl>"
     },
     {
         "word": "niddara",
-        "text": "<dl id='niddara'><dt><dfn>niddara</dfn></dt><dd><p><span class='case'>mfn. id.</span> a term of praise for an ascetic; (not ten? without ten? more than ten?; not in a (conventional) stage of life?)</p></dd></dl>"
+        "text": "<dl id='niddara'><dt><dfn>niddara</dfn></dt><dd><p><span class='case'>neuter</span> free from fever; free from distress (see <i><a href='/define/dara'>dara</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddassa",
-        "text": "<dl id='niddassa'><dt><dfn>niddassa</dfn></dt><dd><p><span class='case'>mfn.</span> sleep; sleepiness; drowsiness.</p></dd></dl>"
+        "text": "<dl id='niddassa'><dt><dfn>niddassa</dfn></dt><dd><p><span class='case'>mfn. id.</span> a term of praise for an ascetic; (not ten? without ten? more than ten?; not in a (conventional) stage of life?)</p></dd></dl>"
     },
     {
         "word": "niddā",
-        "text": "<dl id='niddā'><dt><dfn>niddā</dfn></dt><dd><p><span class='case'>feminine</span> the dispelling of weariness and drowsiness.</p></dd></dl>"
+        "text": "<dl id='niddā'><dt><dfn>niddā</dfn></dt><dd><p><span class='case'>mfn.</span> sleep; sleepiness; drowsiness.</p></dd></dl>"
     },
     {
         "word": "niddākilamathapaṭivinodana",
-        "text": "<dl id='niddākilamathapaṭivinodana'><dt><dfn>niddākilamathapaṭivinodana</dfn></dt><dd><p><span class='case'>neuter</span> cutting; weeding.</p></dd></dl>"
+        "text": "<dl id='niddākilamathapaṭivinodana'><dt><dfn>niddākilamathapaṭivinodana</dfn></dt><dd><p><span class='case'>feminine</span> the dispelling of weariness and drowsiness.</p></dd></dl>"
     },
     {
         "word": "niddāna",
-        "text": "<dl id='niddāna'><dt><dfn>niddāna</dfn></dt><dd><p><span class='case'>neuter</span> cut; weeded.</p></dd></dl>"
+        "text": "<dl id='niddāna'><dt><dfn>niddāna</dfn></dt><dd><p><span class='case'>neuter</span> cutting; weeding.</p></dd></dl>"
     },
     {
         "word": "niddāpetabba",
-        "text": "<dl id='niddāpetabba'><dt><dfn>niddāpetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> cut; weeded.</p></dd></dl>"
+        "text": "<dl id='niddāpetabba'><dt><dfn>niddāpetabba</dfn></dt><dd><p><span class='case'>neuter</span> cut; weeded.</p></dd></dl>"
     },
     {
         "word": "niddāyitabba",
-        "text": "<dl id='niddāyitabba'><dt><dfn>niddāyitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who sleeps.</p></dd></dl>"
-    },
-    {
-        "word": "niddāyitar",
-        "text": "<dl id='niddāyitar'><dt><dfn>niddāyita(r)</dfn></dt><dd><p><span class='case'>masculine</span> pointed out, indicated; defined, specified; explained; declared, proclaimed; foretold (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddāyitabba'><dt><dfn>niddāyitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> cut; weeded.</p></dd></dl>"
     },
     {
         "word": "niddāyita",
-        "text": "<dl id='niddāyita'><dt><dfn>niddāyita(r)</dfn></dt><dd><p><span class='case'>masculine</span> pointed out, indicated; defined, specified; explained; declared, proclaimed; foretold (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddāyitar'><dt><dfn>niddāyita(r)</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who sleeps.</p></dd></dl>"
+    },
+    {
+        "word": "niddāyitar",
+        "text": "<dl id='niddāyitar'><dt><dfn>niddāyita(r)</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who sleeps.</p></dd></dl>"
     },
     {
         "word": "niddiṭṭha",
-        "text": "<dl id='niddiṭṭha'><dt><dfn>niddiṭṭha</dfn></dt><dd><p><span class='case'>pp mfn.</span> points out, indicates; refers to; defines, specifies; explains; proclaims, declares.</p></dd></dl>"
+        "text": "<dl id='niddiṭṭha'><dt><dfn>niddiṭṭha</dfn></dt><dd><p><span class='case'>masculine</span> pointed out, indicated; defined, specified; explained; declared, proclaimed; foretold (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddisati",
-        "text": "<dl id='niddisati'><dt data-main-entry='niddisati'><dfn>niddisati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddisati</span> (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddisati'><dt data-main-entry='niddisati'><dfn>niddisati</dfn></dt><dd><p><span class='case'>pp mfn.</span> points out, indicates; refers to; defines, specifies; explains; proclaims, declares.</p></dd></dl>"
     },
     {
         "word": "niddisi",
-        "text": "<dl id='niddisi'><dt data-main-entry='niddisati'><dfn>niddisi</dfn></dt><dd><p><span class='case'>aor. 3 pl. of niddisati</span> (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddisi'><dt data-main-entry='niddisati'><dfn>niddisi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddisati</span> (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddisitabba",
-        "text": "<dl id='niddisitabba'><dt data-main-entry='niddisati'><dfn>niddisitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (specific) mention or reading.</p></dd></dl>"
+        "text": "<dl id='niddisitabba'><dt data-main-entry='niddisati'><dfn>niddisitabba</dfn></dt><dd><p><span class='case'>aor. 3 pl. of niddisati</span> (see <i><a href='/define/niddisati'>niddisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddesa",
-        "text": "<dl id='niddesa'><dt><dfn>niddesa</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>purified by fire.</li><li>blown off, blown away, got rid off (see <i><a href='/define/nidhamati'>nidhamati</a></i>)</li></ol></dd></dl>"
+        "text": "<dl id='niddesa'><dt><dfn>niddesa</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (specific) mention or reading.</p></dd></dl>"
     },
     {
         "word": "niddhanta",
-        "text": "<dl id='niddhanta'><dt data-main-entry='niddhamati'><dfn>niddhanta</dfn></dt><dd><p><span class='case'>pp mfn.</span> with impurity and delusion got rid of.</p></dd></dl>"
+        "text": "<dl id='niddhanta'><dt data-main-entry='niddhamati'><dfn>niddhanta</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>purified by fire.</li><li>blown off, blown away, got rid off (see <i><a href='/define/nidhamati'>nidhamati</a></i>)</li></ol></dd></dl>"
     },
     {
         "word": "niddhantakasāvamoha",
-        "text": "<dl id='niddhantakasāvamoha'><dt><dfn>niddhantakasāvamoha</dfn></dt><dd><p><span class='case'>mfn.</span> with stains got rid of, without stain.</p></dd></dl>"
+        "text": "<dl id='niddhantakasāvamoha'><dt><dfn>niddhantakasāvamoha</dfn></dt><dd><p><span class='case'>pp mfn.</span> with impurity and delusion got rid of.</p></dd></dl>"
     },
     {
         "word": "niddhantamala",
-        "text": "<dl id='niddhantamala'><dt><dfn>niddhantamala</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>blows on; purifies (by fire)</li><li>(trans.) blows off, blows away; gets rid off.</li></ol></dd></dl>"
+        "text": "<dl id='niddhantamala'><dt><dfn>niddhantamala</dfn></dt><dd><p><span class='case'>mfn.</span> with stains got rid of, without stain.</p></dd></dl>"
     },
     {
         "word": "niddhamati",
-        "text": "<dl id='niddhamati'><dt data-main-entry='niddhamati'><dfn>niddhamati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> a drain; a gutter; a canal.</p></dd></dl>"
+        "text": "<dl id='niddhamati'><dt data-main-entry='niddhamati'><dfn>niddhamati</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>blows on; purifies (by fire)</li><li>(trans.) blows off, blows away; gets rid off.</li></ol></dd></dl>"
     },
     {
         "word": "niddhamana",
-        "text": "<dl id='niddhamana'><dt><dfn>niddhamana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/niddhamati'>niddhamati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddhamana'><dt><dfn>niddhamana</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> a drain; a gutter; a canal.</p></dd></dl>"
     },
     {
         "word": "niddhamaniya",
-        "text": "<dl id='niddhamaniya'><dt><dfn>niddhamaniya</dfn></dt><dd><p><span class='case'>pp mfn. of niddhamati</span> (see <i><a href='/define/niddhamati'>niddhamati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddhamaniya'><dt><dfn>niddhamaniya</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/niddhamati'>niddhamati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddhamitvāna",
-        "text": "<dl id='niddhamitvāna'><dt><dfn>niddhamitvāna</dfn></dt><dd><p><span class='case'>absol.</span> shakes, shakes to and fro; shakes off.</p></dd></dl>"
+        "text": "<dl id='niddhamitvāna'><dt><dfn>niddhamitvāna</dfn></dt><dd><p><span class='case'>pp mfn. of niddhamati</span> (see <i><a href='/define/niddhamati'>niddhamati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddhunāti",
-        "text": "<dl id='niddhunāti'><dt data-main-entry='niddhunāti'><dfn>niddhunāti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddhunāti</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddhunāti'><dt data-main-entry='niddhunāti'><dfn>niddhunāti</dfn></dt><dd><p><span class='case'>absol.</span> shakes, shakes to and fro; shakes off.</p></dd></dl>"
     },
     {
         "word": "niddhuniṃsu",
-        "text": "<dl id='niddhuniṃsu'><dt><dfn>niddhuniṃsu</dfn></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddhuniṃsu'><dt><dfn>niddhuniṃsu</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddhunāti</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddhūnāti",
-        "text": "<dl id='niddhūnāti'><dt><dfn>niddhūnāti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddhovati</span> washed off; got rid off (see <i><a href='/define/niddhovati'>niddhovati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niddhūnāti'><dt><dfn>niddhūnāti</dfn></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddhota",
-        "text": "<dl id='niddhota'><dt data-main-entry='niddhovati'><dfn>niddhota</dfn></dt><dd><p><span class='case'>pp mfn.</span> washes, washes off; gets rid off.</p></dd></dl>"
+        "text": "<dl id='niddhota'><dt data-main-entry='niddhovati'><dfn>niddhota</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niddhovati</span> washed off; got rid off (see <i><a href='/define/niddhovati'>niddhovati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niddhovati",
-        "text": "<dl id='niddhovati'><dt><dfn>niddhovati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> good, skillful at laying by, storing; keeping.</p></dd></dl>"
+        "text": "<dl id='niddhovati'><dt><dfn>niddhovati</dfn></dt><dd><p><span class='case'>pp mfn.</span> washes, washes off; gets rid off.</p></dd></dl>"
     },
     {
         "word": "nidhānakusala",
-        "text": "<dl id='nidhānakusala'><dt><dfn>nidhānakusala</dfn></dt><dd><p><span class='case'>mfn.</span> containing treasure; ? (like treasure; ?) (according to commentaries) worth storing or treasuring.</p></dd></dl>"
+        "text": "<dl id='nidhānakusala'><dt><dfn>nidhānakusala</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> good, skillful at laying by, storing; keeping.</p></dd></dl>"
     },
     {
         "word": "nidhānavatī",
-        "text": "<dl id='nidhānavatī'><dt><dfn>nidhānavatī</dfn></dt><dd><p><span class='case'>(m)f(n). of nidahati</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidhānavatī'><dt><dfn>nidhānavatī</dfn></dt><dd><p><span class='case'>mfn.</span> containing treasure; ? (like treasure; ?) (according to commentaries) worth storing or treasuring.</p></dd></dl>"
     },
     {
         "word": "nidhāpeti",
-        "text": "<dl id='nidhāpeti'><dt data-main-entry='nidahati'><dfn>nidhāpeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nidahati</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidhāpeti'><dt data-main-entry='nidahati'><dfn>nidhāpeti</dfn></dt><dd><p><span class='case'>(m)f(n). of nidahati</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidhāya",
-        "text": "<dl id='nidhāya'><dt data-main-entry='nidahati'><dfn>nidhāya</dfn></dt><dd><p><span class='case'>absol.</span> a store, hoard; treasure.</p></dd></dl>"
+        "text": "<dl id='nidhāya'><dt data-main-entry='nidahati'><dfn>nidhāya</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nidahati</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidhi",
-        "text": "<dl id='nidhi'><dt><dfn>nidhi</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidhi'><dt><dfn>nidhi</dfn></dt><dd><p><span class='case'>absol.</span> a store, hoard; treasure.</p></dd></dl>"
     },
     {
         "word": "nidhunāti",
-        "text": "<dl id='nidhunāti'><dt><dfn>nidhunāti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidhunāti'><dt><dfn>nidhunāti</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niddhunāti'>niddhunāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nidheti",
-        "text": "<dl id='nidheti'><dt><dfn>nidheti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/ninhāta'>ninhāta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nidheti'><dt><dfn>nidheti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
     },
     {
         "word": "ninahāta",
-        "text": "<dl id='ninahāta'><dt><dfn>ninahāta</dfn></dt><dd><p><span class='case'>mfn.</span> blames; criticizes; censures.</p></dd></dl>"
+        "text": "<dl id='ninahāta'><dt><dfn>ninahāta</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/ninhāta'>ninhāta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nindati",
-        "text": "<dl id='nindati'><dt data-main-entry='nindati'><dfn>nindati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> blame, criticism; fault-finding.</p></dd></dl>"
+        "text": "<dl id='nindati'><dt data-main-entry='nindati'><dfn>nindati</dfn></dt><dd><p><span class='case'>mfn.</span> blames; criticizes; censures.</p></dd></dl>"
     },
     {
         "word": "nindā",
-        "text": "<dl id='nindā'><dt><dfn>nindā</dfn></dt><dd><p><span class='case'>feminine</span> fault-finding and offending.</p></dd></dl>"
+        "text": "<dl id='nindā'><dt><dfn>nindā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> blame, criticism; fault-finding.</p></dd></dl>"
     },
     {
         "word": "nindārosa",
-        "text": "<dl id='nindārosa'><dt><dfn>nindārosa</dfn></dt><dd><p><span class='case'>masculine</span> fault-finding and offensive.</p></dd></dl>"
-    },
-    {
-        "word": "nindārosin",
-        "text": "<dl id='nindārosin'><dt><dfn>nindārosi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> fear of fault-finding, insult and criticism.</p></dd></dl>"
+        "text": "<dl id='nindārosa'><dt><dfn>nindārosa</dfn></dt><dd><p><span class='case'>feminine</span> fault-finding and offending.</p></dd></dl>"
     },
     {
         "word": "nindārosi",
-        "text": "<dl id='nindārosi'><dt><dfn>nindārosi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> fear of fault-finding, insult and criticism.</p></dd></dl>"
+        "text": "<dl id='nindārosin'><dt><dfn>nindārosi(n)</dfn></dt><dd><p><span class='case'>masculine</span> fault-finding and offensive.</p></dd></dl>"
+    },
+    {
+        "word": "nindārosin",
+        "text": "<dl id='nindārosin'><dt><dfn>nindārosi(n)</dfn></dt><dd><p><span class='case'>masculine</span> fault-finding and offensive.</p></dd></dl>"
     },
     {
         "word": "nindāvyārosa-upārambhabhaya",
-        "text": "<dl id='nindāvyārosa-upārambhabhaya'><dt><dfn>nindāvyārosa-upārambhabhaya</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nindāvyārosa-upārambhabhaya'>nindāvyārosa-upārambhabhaya</a></i>)</p></dd></dl>"
+        "text": "<dl id='nindāvyārosa-upārambhabhaya'><dt><dfn>nindāvyārosa-upārambhabhaya</dfn></dt><dd><p><span class='case'>mfn.</span> fear of fault-finding, insult and criticism.</p></dd></dl>"
     },
     {
         "word": "nindāvyārosana-upārambhabhaya",
-        "text": "<dl id='nindāvyārosana-upārambhabhaya'><dt><dfn>nindāvyārosana-upārambhabhaya</dfn></dt><dd><p><span class='case'>neuter id. of nindati</span> blamed; criticized (see <i><a href='/define/nindati'>nindati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nindāvyārosana-upārambhabhaya'><dt><dfn>nindāvyārosana-upārambhabhaya</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nindāvyārosa-upārambhabhaya'>nindāvyārosa-upārambhabhaya</a></i>)</p></dd></dl>"
     },
     {
         "word": "nindita",
-        "text": "<dl id='nindita'><dt data-main-entry='nindati'><dfn>nindita</dfn></dt><dd><p><span class='case'>pp mfn. of nindati</span></p><ol type='1' class='decimal'><li>(n.) low ground; a hollow, a depression.</li><li>(mfn.)<ol type='i' class='lower-roman'><li>low, low-lying, sunken; deep.</li><li>bending towards; inclined towards (see <i><a href='/define/nindati'>nindati</a></i>)</li></ol></li></ol></dd></dl>"
+        "text": "<dl id='nindita'><dt data-main-entry='nindati'><dfn>nindita</dfn></dt><dd><p><span class='case'>neuter id. of nindati</span> blamed; criticized (see <i><a href='/define/nindati'>nindati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nindiya",
-        "text": "<dl id='nindiya'><dt><dfn>nindiya</dfn></dt><dd><p><span class='case'>neuter</span> low ground; a hollow, a depression</p><span class='case'>mfn.</span><ol type='i' class='lower-roman'><li>low, low-lying, sunken; deep.</li><li>bending towards; inclined towards.</li></ol></dd></dl>"
+        "text": "<dl id='nindiya'><dt><dfn>nindiya</dfn></dt><dd><p><span class='case'>pp mfn. of nindati</span></p><ol type='1' class='decimal'><li>(n.) low ground; a hollow, a depression.</li><li>(mfn.)<ol type='i' class='lower-roman'><li>low, low-lying, sunken; deep.</li><li>bending towards; inclined towards (see <i><a href='/define/nindati'>nindati</a></i>)</li></ol></li></ol></dd></dl>"
     },
     {
         "word": "ninna",
-        "text": "<dl id='ninna'><dt><dfn>ninna</dfn></dt><dd><p><span class='case'>neuter & mfn.</span> resounding, resonant; of deeper timber.</p></dd></dl>"
-    },
-    {
-        "word": "ninnādin",
-        "text": "<dl id='ninnādin'><dt><dfn>ninnādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ninnāmeti'>ninnāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='ninna'><dt><dfn>ninna</dfn></dt><dd><p><span class='case'>neuter</span> low ground; a hollow, a depression</p><span class='case'>mfn.</span><ol type='i' class='lower-roman'><li>low, low-lying, sunken; deep.</li><li>bending towards; inclined towards.</li></ol></dd></dl>"
     },
     {
         "word": "ninnādi",
-        "text": "<dl id='ninnādi'><dt><dfn>ninnādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ninnāmeti'>ninnāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='ninnādin'><dt><dfn>ninnādi(n)</dfn></dt><dd><p><span class='case'>neuter & mfn.</span> resounding, resonant; of deeper timber.</p></dd></dl>"
+    },
+    {
+        "word": "ninnādin",
+        "text": "<dl id='ninnādin'><dt><dfn>ninnādi(n)</dfn></dt><dd><p><span class='case'>neuter & mfn.</span> resounding, resonant; of deeper timber.</p></dd></dl>"
     },
     {
         "word": "ninnāmayati",
-        "text": "<dl id='ninnāmayati'><dt><dfn>ninnāmayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> puts out (the tongue)</p></dd></dl>"
+        "text": "<dl id='ninnāmayati'><dt><dfn>ninnāmayati</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ninnāmeti'>ninnāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "ninnāmeti",
-        "text": "<dl id='ninnāmeti'><dt data-main-entry='ninnāmeti'><dfn>ninnāmeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of ninnāmeti</span> (see <i><a href='/define/ninnāmeti'>ninnāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='ninnāmeti'><dt data-main-entry='ninnāmeti'><dfn>ninnāmeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> puts out (the tongue)</p></dd></dl>"
     },
     {
         "word": "ninnāmetvā",
-        "text": "<dl id='ninnāmetvā'><dt data-main-entry='ninnāmeti'><dfn>ninnāmetvā</dfn></dt><dd><p><span class='case'>absol.</span> washed off; cleaned off.</p></dd></dl>"
+        "text": "<dl id='ninnāmetvā'><dt data-main-entry='ninnāmeti'><dfn>ninnāmetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of ninnāmeti</span> (see <i><a href='/define/ninnāmeti'>ninnāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "ninnīta",
-        "text": "<dl id='ninnīta'><dt><dfn>ninnīta</dfn></dt><dd><p><span class='case'>mfn.</span> with impurities cleaned off.</p></dd></dl>"
+        "text": "<dl id='ninnīta'><dt><dfn>ninnīta</dfn></dt><dd><p><span class='case'>absol.</span> washed off; cleaned off.</p></dd></dl>"
     },
     {
         "word": "ninnītakasāva",
-        "text": "<dl id='ninnītakasāva'><dt><dfn>ninnītakasāva</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ninneti'>ninneti</a></i>)</p></dd></dl>"
+        "text": "<dl id='ninnītakasāva'><dt><dfn>ninnītakasāva</dfn></dt><dd><p><span class='case'>mfn.</span> with impurities cleaned off.</p></dd></dl>"
     },
     {
         "word": "ninnetabba",
-        "text": "<dl id='ninnetabba'><dt><dfn>ninnetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who ascertains, settles; a guide.</p></dd></dl>"
-    },
-    {
-        "word": "ninnetar",
-        "text": "<dl id='ninnetar'><dt><dfn>ninneta(r)</dfn></dt><dd><p><span class='case'>masculine</span> leads or takes away; takes out; drains; ascertains.</p></dd></dl>"
+        "text": "<dl id='ninnetabba'><dt><dfn>ninnetabba</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ninneti'>ninneti</a></i>)</p></dd></dl>"
     },
     {
         "word": "ninneta",
-        "text": "<dl id='ninneta'><dt><dfn>ninneta(r)</dfn></dt><dd><p><span class='case'>masculine</span> leads or takes away; takes out; drains; ascertains.</p></dd></dl>"
+        "text": "<dl id='ninnetar'><dt><dfn>ninneta(r)</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who ascertains, settles; a guide.</p></dd></dl>"
+    },
+    {
+        "word": "ninnetar",
+        "text": "<dl id='ninnetar'><dt><dfn>ninneta(r)</dfn></dt><dd><p><span class='case'>fpp mfn.</span> one who ascertains, settles; a guide.</p></dd></dl>"
     },
     {
         "word": "ninneti",
-        "text": "<dl id='ninneti'><dt><dfn>ninneti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> leads or takes away; takes out; drains; ascertains.</p></dd></dl>"
+        "text": "<dl id='ninneti'><dt><dfn>ninneti</dfn></dt><dd><p><span class='case'>masculine</span> leads or takes away; takes out; drains; ascertains.</p></dd></dl>"
     },
     {
         "word": "ninnetvā",
-        "text": "<dl id='ninnetvā'><dt><dfn>ninnetvā</dfn></dt><dd><p><span class='case'>absol.</span> washed, cleansed.</p></dd></dl>"
+        "text": "<dl id='ninnetvā'><dt><dfn>ninnetvā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> leads or takes away; takes out; drains; ascertains.</p></dd></dl>"
     },
     {
         "word": "ninhāta",
-        "text": "<dl id='ninhāta'><dt><dfn>ninhāta</dfn></dt><dd><p><span class='case'>mfn.</span> cleansed off evil.</p></dd></dl>"
+        "text": "<dl id='ninhāta'><dt><dfn>ninhāta</dfn></dt><dd><p><span class='case'>absol.</span> washed, cleansed.</p></dd></dl>"
     },
     {
         "word": "ninhātapāpaka",
-        "text": "<dl id='ninhātapāpaka'><dt><dfn>ninhātapāpaka</dfn></dt><dd><p><span class='case'>mfn.</span> washing; cleansing.</p></dd></dl>"
+        "text": "<dl id='ninhātapāpaka'><dt><dfn>ninhātapāpaka</dfn></dt><dd><p><span class='case'>mfn.</span> cleansed off evil.</p></dd></dl>"
     },
     {
         "word": "ninhāya",
-        "text": "<dl id='ninhāya'><dt><dfn>ninhāya</dfn></dt><dd><p><span class='case'>indeclinable</span> intelligent; clever; adept.</p></dd></dl>"
+        "text": "<dl id='ninhāya'><dt><dfn>ninhāya</dfn></dt><dd><p><span class='case'>mfn.</span> washing; cleansing.</p></dd></dl>"
     },
     {
         "word": "nipaka",
-        "text": "<dl id='nipaka'><dt><dfn>nipaka</dfn></dt><dd><p><span class='case'>mfn.</span> humbleness; obedience; respect.</p></dd></dl>"
+        "text": "<dl id='nipaka'><dt><dfn>nipaka</dfn></dt><dd><p><span class='case'>indeclinable</span> intelligent; clever; adept.</p></dd></dl>"
     },
     {
         "word": "nipaccakāra",
-        "text": "<dl id='nipaccakāra'><dt><dfn>nipaccakāra</dfn></dt><dd><p><span class='case'>masculine</span> speaking humbly; speaking hurtfully?</p></dd></dl>"
-    },
-    {
-        "word": "nipaccavādin",
-        "text": "<dl id='nipaccavādin'><dt><dfn>nipaccavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nipaccakāra'>nipaccakāra</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipaccakāra'><dt><dfn>nipaccakāra</dfn></dt><dd><p><span class='case'>mfn.</span> humbleness; obedience; respect.</p></dd></dl>"
     },
     {
         "word": "nipaccavādi",
-        "text": "<dl id='nipaccavādi'><dt><dfn>nipaccavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nipaccakāra'>nipaccakāra</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipaccavādin'><dt><dfn>nipaccavādi(n)</dfn></dt><dd><p><span class='case'>masculine</span> speaking humbly; speaking hurtfully?</p></dd></dl>"
+    },
+    {
+        "word": "nipaccavādin",
+        "text": "<dl id='nipaccavādin'><dt><dfn>nipaccavādi(n)</dfn></dt><dd><p><span class='case'>masculine</span> speaking humbly; speaking hurtfully?</p></dd></dl>"
     },
     {
         "word": "nipaccākāra",
-        "text": "<dl id='nipaccākāra'><dt><dfn>nipaccākāra</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipaccākāra'><dt><dfn>nipaccākāra</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nipaccakāra'>nipaccakāra</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajjaṃ",
-        "text": "<dl id='nipajjaṃ'><dt><dfn>nipajjaṃ</dfn></dt><dd><p><span class='case'>fut. 1 sg.</span> lies down.</p></dd></dl>"
+        "text": "<dl id='nipajjaṃ'><dt><dfn>nipajjaṃ</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajjati",
-        "text": "<dl id='nipajjati'><dt data-main-entry='nipajjati'><dfn>nipajjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> lying down.</p></dd></dl>"
+        "text": "<dl id='nipajjati'><dt data-main-entry='nipajjati'><dfn>nipajjati</dfn></dt><dd><p><span class='case'>fut. 1 sg.</span> lies down.</p></dd></dl>"
     },
     {
         "word": "nipajjā",
-        "text": "<dl id='nipajjā'><dt><dfn>nipajjā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipajjā'><dt><dfn>nipajjā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> lying down.</p></dd></dl>"
     },
     {
         "word": "nipajjāpetvā",
-        "text": "<dl id='nipajjāpetvā'><dt><dfn>nipajjāpetvā</dfn></dt><dd><p><span class='case'>absol. of nipajjati</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipajjāpetvā'><dt><dfn>nipajjāpetvā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajji",
-        "text": "<dl id='nipajji'><dt data-main-entry='nipajjati'><dfn>nipajji</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipajjati</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipajji'><dt data-main-entry='nipajjati'><dfn>nipajji</dfn></dt><dd><p><span class='case'>absol. of nipajjati</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajjiṃsu",
-        "text": "<dl id='nipajjiṃsu'><dt><dfn>nipajjiṃsu</dfn></dt><dd><p><span class='case'>3 pl. of nipajjati</span> having laid down; having slept (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipajjiṃsu'><dt><dfn>nipajjiṃsu</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipajjati</span> (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajjitvā",
-        "text": "<dl id='nipajjitvā'><dt data-main-entry='nipajjati'><dfn>nipajjitvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nipajjaṃ'>nipajjaṃ</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipajjitvā'><dt data-main-entry='nipajjati'><dfn>nipajjitvā</dfn></dt><dd><p><span class='case'>3 pl. of nipajjati</span> having laid down; having slept (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipajjisāmi",
-        "text": "<dl id='nipajjisāmi'><dt><dfn>nipajjisāmi</dfn></dt><dd><p><span class='case'>fut. 1 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
-    },
-    {
-        "word": "nipatat",
-        "text": "<dl id='nipatat'><dt><dfn>nipata(t)</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span></p><ol type='1' class='decimal'><li>falls down or off; falls down into; sinks; falls upon; falls down before.</li><li>flies down; alights; comes down; settles; sits down; lies down.</li><li>comes upon; invites, entertains.</li></ol></dd></dl>"
+        "text": "<dl id='nipajjisāmi'><dt><dfn>nipajjisāmi</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nipajjaṃ'>nipajjaṃ</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipata",
-        "text": "<dl id='nipata'><dt><dfn>nipata(t)</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span></p><ol type='1' class='decimal'><li>falls down or off; falls down into; sinks; falls upon; falls down before.</li><li>flies down; alights; comes down; settles; sits down; lies down.</li><li>comes upon; invites, entertains.</li></ol></dd></dl>"
+        "text": "<dl id='nipatat'><dt><dfn>nipata(t)</dfn></dt><dd><p><span class='case'>fut. 1 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
+    },
+    {
+        "word": "nipatat",
+        "text": "<dl id='nipatat'><dt><dfn>nipata(t)</dfn></dt><dd><p><span class='case'>fut. 1 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipatati",
-        "text": "<dl id='nipatati'><dt data-main-entry='nipatati'><dfn>nipatati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipatati'><dt data-main-entry='nipatati'><dfn>nipatati</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span></p><ol type='1' class='decimal'><li>falls down or off; falls down into; sinks; falls upon; falls down before.</li><li>flies down; alights; comes down; settles; sits down; lies down.</li><li>comes upon; invites, entertains.</li></ol></dd></dl>"
     },
     {
         "word": "nipatanta",
-        "text": "<dl id='nipatanta'><dt><dfn>nipatanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipatanta'><dt><dfn>nipatanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipatitvā",
-        "text": "<dl id='nipatitvā'><dt data-main-entry='nipatati'><dfn>nipatitvā</dfn></dt><dd><p><span class='case'>absol. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipatitvā'><dt data-main-entry='nipatati'><dfn>nipatitvā</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipatī",
-        "text": "<dl id='nipatī'><dt><dfn>nipatī</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipajjati</span> lying down (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipatī'><dt><dfn>nipatī</dfn></dt><dd><p><span class='case'>absol. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipanna",
-        "text": "<dl id='nipanna'><dt data-main-entry='nipajjati'><dfn>nipanna</dfn></dt><dd><p><span class='case'>pp mfn.</span> the place where (someone) lies or is lying down.</p></dd></dl>"
+        "text": "<dl id='nipanna'><dt data-main-entry='nipajjati'><dfn>nipanna</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipajjati</span> lying down (see <i><a href='/define/nipajjati'>nipajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipannokasa",
-        "text": "<dl id='nipannokasa'><dt><dfn>nipannokasa</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>fall, falling; descent; settling.</li><li>a section of a book.</li></ol></dd></dl>"
+        "text": "<dl id='nipannokasa'><dt><dfn>nipannokasa</dfn></dt><dd><p><span class='case'>pp mfn.</span> the place where (someone) lies or is lying down.</p></dd></dl>"
     },
     {
         "word": "nipāta",
-        "text": "<dl id='nipāta'><dt><dfn>nipāta</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipāta'><dt><dfn>nipāta</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>fall, falling; descent; settling.</li><li>a section of a book.</li></ol></dd></dl>"
     },
     {
         "word": "nipātayati",
-        "text": "<dl id='nipātayati'><dt><dfn>nipātayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span></p><ol type='1' class='decimal'><li>makes fall down (on), makes lie down; lowers; throws down; fixes, fixes (the teeth) in; casts upon, imputes; (brings together; ?)</li><li>inlays, embosses.</li><li>sets down as a special or irregular form.</li></ol></dd></dl>"
+        "text": "<dl id='nipātayati'><dt><dfn>nipātayati</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipāteti",
-        "text": "<dl id='nipāteti'><dt data-main-entry='nipatati'><dfn>nipāteti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipāteti'><dt data-main-entry='nipatati'><dfn>nipāteti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span></p><ol type='1' class='decimal'><li>makes fall down (on), makes lie down; lowers; throws down; fixes, fixes (the teeth) in; casts upon, imputes; (brings together; ?)</li><li>inlays, embosses.</li><li>sets down as a special or irregular form.</li></ol></dd></dl>"
     },
     {
         "word": "nipātetvā",
-        "text": "<dl id='nipātetvā'><dt data-main-entry='nipatati'><dfn>nipātetvā</dfn></dt><dd><p><span class='case'>absol. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipātetvā'><dt data-main-entry='nipatati'><dfn>nipātetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nipatati</span> (see <i><a href='/define/nipatati'>nipatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipātenta",
-        "text": "<dl id='nipātenta'><dt data-main-entry='nipatati'><dfn>nipātenta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipātenta'><dt data-main-entry='nipatati'><dfn>nipātenta</dfn></dt><dd><p><span class='case'>absol. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipātesi",
-        "text": "<dl id='nipātesi'><dt data-main-entry='nipatati'><dfn>nipātesi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipātesi'><dt data-main-entry='nipatati'><dfn>nipātesi</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipātesuṃ",
-        "text": "<dl id='nipātesuṃ'><dt><dfn>nipātesuṃ</dfn></dt><dd><p><span class='case'>inf.</span> (see <i><a href='/define/nippīḷana'>nippīḷana</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipātesuṃ'><dt><dfn>nipātesuṃ</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nipāteti</span> (see <i><a href='/define/nipāteti'>nipāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipīlana",
-        "text": "<dl id='nipīlana'><dt><dfn>nipīlana</dfn></dt><dd><p><span class='case'>neuter</span></p><ol type='1' class='decimal'><li>clever; skillful; subtle; acute.</li><li>(what is) subtle, abstruse.</li></ol></dd></dl>"
+        "text": "<dl id='nipīlana'><dt><dfn>nipīlana</dfn></dt><dd><p><span class='case'>inf.</span> (see <i><a href='/define/nippīḷana'>nippīḷana</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipuṇa",
-        "text": "<dl id='nipuṇa'><dt><dfn>nipuṇa</dfn></dt><dd><p><span class='case'>mfn.</span> cooked (see <i><a href='/define/nippacati'>nippacati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipuṇa'><dt><dfn>nipuṇa</dfn></dt><dd><p><span class='case'>neuter</span></p><ol type='1' class='decimal'><li>clever; skillful; subtle; acute.</li><li>(what is) subtle, abstruse.</li></ol></dd></dl>"
     },
     {
         "word": "nippakka",
-        "text": "<dl id='nippakka'><dt><dfn>nippakka</dfn></dt><dd><p><span class='case'>mfn.</span> cooks; infuses.</p></dd></dl>"
+        "text": "<dl id='nippakka'><dt><dfn>nippakka</dfn></dt><dd><p><span class='case'>mfn.</span> cooked (see <i><a href='/define/nippacati'>nippacati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippacati",
-        "text": "<dl id='nippacati'><dt><dfn>nippacati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> cooks; infuses.</p></dd></dl>"
+        "text": "<dl id='nippacati'><dt><dfn>nippacati</dfn></dt><dd><p><span class='case'>mfn.</span> cooks; infuses.</p></dd></dl>"
     },
     {
         "word": "nippaci",
-        "text": "<dl id='nippaci'><dt><dfn>nippaci</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nipphaṭati'>nipphaṭati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippaci'><dt><dfn>nippaci</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> cooks; infuses.</p></dd></dl>"
     },
     {
         "word": "nippaṭati",
-        "text": "<dl id='nippaṭati'><dt><dfn>nippaṭati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> flies out, rushes out; falls out; departs, hastens away.</p></dd></dl>"
+        "text": "<dl id='nippaṭati'><dt><dfn>nippaṭati</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nipphaṭati'>nipphaṭati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippatati",
-        "text": "<dl id='nippatati'><dt><dfn>nippatati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nippatati</span> (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippatati'><dt><dfn>nippatati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> flies out, rushes out; falls out; departs, hastens away.</p></dd></dl>"
     },
     {
         "word": "nippati",
-        "text": "<dl id='nippati'><dt><dfn>nippati</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nippatati</span> flown out; hastened away (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippati'><dt><dfn>nippati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nippatati</span> (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippatita",
-        "text": "<dl id='nippatita'><dt><dfn>nippatita</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippatita'><dt><dfn>nippatita</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nippatati</span> flown out; hastened away (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippatitvā",
-        "text": "<dl id='nippatitvā'><dt><dfn>nippatitvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nipphadā'>nipphadā</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippatitvā'><dt><dfn>nippatitvā</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nippatati'>nippatati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippadā",
-        "text": "<dl id='nippadā'><dt><dfn>nippadā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nippatita'>nippatita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippadā'><dt><dfn>nippadā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nipphadā'>nipphadā</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippātita",
-        "text": "<dl id='nippātita'><dt><dfn>nippātita</dfn></dt><dd><p><span class='case'>pp mfn. of nippatita</span> (see <i><a href='/define/nippatita'>nippatita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippātita'><dt><dfn>nippātita</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nippatita'>nippatita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippātesi",
-        "text": "<dl id='nippātesi'><dt><dfn>nippātesi</dfn></dt><dd><p><span class='case'>caus. aor. 3 sg.</span> not involving or accompanied by joy.</p></dd></dl>"
+        "text": "<dl id='nippātesi'><dt><dfn>nippātesi</dfn></dt><dd><p><span class='case'>pp mfn. of nippatita</span> (see <i><a href='/define/nippatita'>nippatita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippītika",
-        "text": "<dl id='nippītika'><dt><dfn>nippītika</dfn></dt><dd><p><span class='case'>mfn.</span> squeezing; pressing; pressing against.</p></dd></dl>"
+        "text": "<dl id='nippītika'><dt><dfn>nippītika</dfn></dt><dd><p><span class='case'>caus. aor. 3 sg.</span> not involving or accompanied by joy.</p></dd></dl>"
     },
     {
         "word": "nippīḷana",
-        "text": "<dl id='nippīḷana'><dt><dfn>nippīḷana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nippīḷana'>nippīḷana</a></i>)</p></dd></dl>"
+        "text": "<dl id='nippīḷana'><dt><dfn>nippīḷana</dfn></dt><dd><p><span class='case'>mfn.</span> squeezing; pressing; pressing against.</p></dd></dl>"
     },
     {
         "word": "nippīḷanā",
-        "text": "<dl id='nippīḷanā'><dt><dfn>nippīḷanā</dfn></dt><dd><p><span class='case'>feminine</span> presses; squeezes.</p></dd></dl>"
+        "text": "<dl id='nippīḷanā'><dt><dfn>nippīḷanā</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nippīḷana'>nippīḷana</a></i>)</p></dd></dl>"
     },
     {
         "word": "nippīḷiyamāna",
-        "text": "<dl id='nippīḷiyamāna'><dt><dfn>nippīḷiyamāna</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn.</span> one who solicits gifts in an inappropriate way; (according to commentaries : one who grinds or scrapes away, who belittles or denies the good qualities of others for his own advantage)</p></dd></dl>"
+        "text": "<dl id='nippīḷiyamāna'><dt><dfn>nippīḷiyamāna</dfn></dt><dd><p><span class='case'>feminine</span> presses; squeezes.</p></dd></dl>"
     },
     {
         "word": "nippesika",
-        "text": "<dl id='nippesika'><dt><dfn>nippesika</dfn></dt><dd><p><span class='case'>masculine</span> soliciting gifts in an inappropriate way; (according to commentaries : by grinding away, belittling or denying others’ good qualities)</p></dd></dl>"
+        "text": "<dl id='nippesika'><dt><dfn>nippesika</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn.</span> one who solicits gifts in an inappropriate way; (according to commentaries : one who grinds or scrapes away, who belittles or denies the good qualities of others for his own advantage)</p></dd></dl>"
     },
     {
         "word": "nippesikatā",
-        "text": "<dl id='nippesikatā'><dt><dfn>nippesikatā</dfn></dt><dd><p><span class='case'>f., abstr.</span> accomplishment; completion.</p></dd></dl>"
+        "text": "<dl id='nippesikatā'><dt><dfn>nippesikatā</dfn></dt><dd><p><span class='case'>masculine</span> soliciting gifts in an inappropriate way; (according to commentaries : by grinding away, belittling or denying others’ good qualities)</p></dd></dl>"
     },
     {
         "word": "nipphadā",
-        "text": "<dl id='nipphadā'><dt><dfn>nipphadā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipphadā'><dt><dfn>nipphadā</dfn></dt><dd><p><span class='case'>f., abstr.</span> accomplishment; completion.</p></dd></dl>"
     },
     {
         "word": "nippoṭheti",
-        "text": "<dl id='nippoṭheti'><dt><dfn>nippoṭheti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> shakes; shakes to and fro.</p></dd></dl>"
+        "text": "<dl id='nippoṭheti'><dt><dfn>nippoṭheti</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipphoṭeti",
-        "text": "<dl id='nipphoṭeti'><dt><dfn>nipphoṭeti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> shakes; shakes to and fro; (beats; ?)</p></dd></dl>"
+        "text": "<dl id='nipphoṭeti'><dt><dfn>nipphoṭeti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> shakes; shakes to and fro.</p></dd></dl>"
     },
     {
         "word": "nipphotayati",
-        "text": "<dl id='nipphotayati'><dt><dfn>nipphotayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> dashes down; crushes.</p></dd></dl>"
+        "text": "<dl id='nipphotayati'><dt><dfn>nipphotayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> shakes; shakes to and fro; (beats; ?)</p></dd></dl>"
     },
     {
         "word": "nipphoteti",
-        "text": "<dl id='nipphoteti'><dt><dfn>nipphoteti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipphoteti'><dt><dfn>nipphoteti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> dashes down; crushes.</p></dd></dl>"
     },
     {
         "word": "nipphotenta",
-        "text": "<dl id='nipphotenta'><dt><dfn>nipphotenta</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> moves from its place; falls.</p></dd></dl>"
+        "text": "<dl id='nipphotenta'><dt><dfn>nipphotenta</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nipphaṭati",
-        "text": "<dl id='nipphaṭati'><dt><dfn>nipphaṭati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> splendid when accomplished.</p></dd></dl>"
+        "text": "<dl id='nipphaṭati'><dt><dfn>nipphaṭati</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> moves from its place; falls.</p></dd></dl>"
     },
     {
         "word": "nipphannasobhana",
-        "text": "<dl id='nipphannasobhana'><dt><dfn>nipphannasobhana</dfn></dt><dd><p><span class='case'>mfn.</span> splendid when accomplished.</p></dd></dl>"
-    },
-    {
-        "word": "nipphannasobhin",
-        "text": "<dl id='nipphannasobhin'><dt><dfn>nipphannasobhi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nipphannasobhana'>nipphannasobhana</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipphannasobhana'><dt><dfn>nipphannasobhana</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> splendid when accomplished.</p></dd></dl>"
     },
     {
         "word": "nipphannasobhi",
-        "text": "<dl id='nipphannasobhi'><dt><dfn>nipphannasobhi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nipphannasobhana'>nipphannasobhana</a></i>)</p></dd></dl>"
+        "text": "<dl id='nipphannasobhin'><dt><dfn>nipphannasobhi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> splendid when accomplished.</p></dd></dl>"
+    },
+    {
+        "word": "nipphannasobhin",
+        "text": "<dl id='nipphannasobhin'><dt><dfn>nipphannasobhi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> splendid when accomplished.</p></dd></dl>"
     },
     {
         "word": "nipphoṭenta",
-        "text": "<dl id='nipphoṭenta'><dt data-main-entry='nipphoṭeti'><dfn>nipphoṭenta</dfn><sup>1</sup></dt><dd><p><span class='case'>part. pr. mfn. of nipphoṭeti</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd><dt><dfn>nipphoṭenta</dfn><sup>2</sup></dt><dd><p><span class='case'>part. pr. mfn.</span> dressed with oil?</p></dd></dl>"
+        "text": "<dl id='nipphoṭenta'><dt data-main-entry='nipphoṭeti'><dfn>nipphoṭenta</dfn><sup>1</sup></dt><dd><p><span class='case'>part. pr. mfn. of nipphoṭeti</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd><dt><dfn>nipphoṭenta</dfn><sup>2</sup></dt><dd><p><span class='case'>part. pr. mfn. of nipphoṭeti</span> (see <i><a href='/define/nipphoṭeti'>nipphoṭeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibaddhatelaka",
-        "text": "<dl id='nibaddhatelaka'><dt><dfn>nibaddhatelaka</dfn></dt><dd><p><span class='case'>mfn.</span> binds, ties; fetters; fixes.</p></dd></dl>"
+        "text": "<dl id='nibaddhatelaka'><dt><dfn>nibaddhatelaka</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> dressed with oil?</p></dd></dl>"
     },
     {
         "word": "nibandhati",
-        "text": "<dl id='nibandhati'><dt data-main-entry='nibandhati'><dfn>nibandhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> oppresses; harasses.</p></dd></dl>"
+        "text": "<dl id='nibandhati'><dt data-main-entry='nibandhati'><dfn>nibandhati</dfn></dt><dd><p><span class='case'>mfn.</span> binds, ties; fetters; fixes.</p></dd></dl>"
     },
     {
         "word": "nibādhayati",
-        "text": "<dl id='nibādhayati'><dt><dfn>nibādhayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> teaches, instructs; rouses.</p></dd></dl>"
+        "text": "<dl id='nibādhayati'><dt><dfn>nibādhayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> oppresses; harasses.</p></dd></dl>"
     },
     {
         "word": "nibodheti",
-        "text": "<dl id='nibodheti'><dt><dfn>nibodheti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> the gutter, the edge, of the eaves; the shelter of the eaves; ?</p></dd></dl>"
+        "text": "<dl id='nibodheti'><dt><dfn>nibodheti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> teaches, instructs; rouses.</p></dd></dl>"
     },
     {
         "word": "nibbakosa",
-        "text": "<dl id='nibbakosa'><dt><dfn>nibbakosa</dfn></dt><dd><p><span class='case'>masculine</span> shunning; abandoning.</p></dd></dl>"
-    },
-    {
-        "word": "nibbajjayat",
-        "text": "<dl id='nibbajjayat'><dt><dfn>nibbajjaya(t)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbakosa'><dt><dfn>nibbakosa</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> the gutter, the edge, of the eaves; the shelter of the eaves; ?</p></dd></dl>"
     },
     {
         "word": "nibbajjaya",
-        "text": "<dl id='nibbajjaya'><dt><dfn>nibbajjaya(t)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbajjayat'><dt><dfn>nibbajjaya(t)</dfn></dt><dd><p><span class='case'>masculine</span> shunning; abandoning.</p></dd></dl>"
+    },
+    {
+        "word": "nibbajjayat",
+        "text": "<dl id='nibbajjayat'><dt><dfn>nibbajjaya(t)</dfn></dt><dd><p><span class='case'>masculine</span> shunning; abandoning.</p></dd></dl>"
     },
     {
         "word": "nibbaṭṭeti",
-        "text": "<dl id='nibbaṭṭeti'><dt><dfn>nibbaṭṭeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbattati</span></p><ol type='i' class='lower-roman'><li>arisen; originated; come into being; developed.</li><li>removed? (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</li></ol></dd></dl>"
+        "text": "<dl id='nibbaṭṭeti'><dt><dfn>nibbaṭṭeti</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbatta",
-        "text": "<dl id='nibbatta'><dt data-main-entry='nibbattati'><dfn>nibbatta</dfn></dt><dd><p><span class='case'>pp mfn & neuter</span> with the seed removed; (or with the seed fully developed?)</p></dd></dl>"
+        "text": "<dl id='nibbatta'><dt data-main-entry='nibbattati'><dfn>nibbatta</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbattati</span></p><ol type='i' class='lower-roman'><li>arisen; originated; come into being; developed.</li><li>removed? (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</li></ol></dd></dl>"
     },
     {
         "word": "nibbattabīja",
-        "text": "<dl id='nibbattabīja'><dt><dfn>nibbattabīja</dfn></dt><dd><p><span class='case'>mfn.</span> arises; comes into being; appears; becomes.</p></dd></dl>"
+        "text": "<dl id='nibbattabīja'><dt><dfn>nibbattabīja</dfn></dt><dd><p><span class='case'>pp mfn & neuter</span> with the seed removed; (or with the seed fully developed?)</p></dd></dl>"
     },
     {
         "word": "nibbattati",
-        "text": "<dl id='nibbattati'><dt data-main-entry='nibbattati'><dfn>nibbattati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattati'><dt data-main-entry='nibbattati'><dfn>nibbattati</dfn></dt><dd><p><span class='case'>mfn.</span> arises; comes into being; appears; becomes.</p></dd></dl>"
     },
     {
         "word": "nibbattayati",
-        "text": "<dl id='nibbattayati'><dt><dfn>nibbattayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbattati</span> (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattayati'><dt><dfn>nibbattayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbatti",
-        "text": "<dl id='nibbatti'><dt><dfn>nibbatti</dfn><sup>1</sup></dt><dd><p><span class='case'>aor. 3 sg.</span> coming into being; origination; appearance.</p></dd><dt><dfn>nibbatti</dfn><sup>2</sup></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbatti'><dt><dfn>nibbatti</dfn><sup>1</sup></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbattati</span> (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd><dt><dfn>nibbatti</dfn><sup>2</sup></dt><dd><p><span class='case'>aor. 3 sg.</span> coming into being; origination; appearance.</p></dd></dl>"
     },
     {
         "word": "nibbattitvā",
-        "text": "<dl id='nibbattitvā'><dt data-main-entry='nibbattati'><dfn>nibbattitvā</dfn></dt><dd><p><span class='case'>absol. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattitvā'><dt data-main-entry='nibbattati'><dfn>nibbattitvā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbattetabba",
-        "text": "<dl id='nibbattetabba'><dt data-main-entry='nibbattati'><dfn>nibbattetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> produces; brings forth; brings into being (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattetabba'><dt data-main-entry='nibbattati'><dfn>nibbattetabba</dfn></dt><dd><p><span class='case'>absol. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbatteti",
-        "text": "<dl id='nibbatteti'><dt data-main-entry='nibbattati'><dfn>nibbatteti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbatteti'><dt data-main-entry='nibbattati'><dfn>nibbatteti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> produces; brings forth; brings into being (see <i><a href='/define/nibbattati'>nibbattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbattetuṃ",
-        "text": "<dl id='nibbattetuṃ'><dt><dfn>nibbattetuṃ</dfn></dt><dd><p><span class='case'>inf. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattetuṃ'><dt><dfn>nibbattetuṃ</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbattetvā",
-        "text": "<dl id='nibbattetvā'><dt data-main-entry='nibbattati'><dfn>nibbattetvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbattetvā'><dt data-main-entry='nibbattati'><dfn>nibbattetvā</dfn></dt><dd><p><span class='case'>inf. of nibbatteti</span> (see <i><a href='/define/nibbatteti'>nibbatteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbandhati",
@@ -51940,12 +51940,12 @@
         "text": "<dl id='nibbānagamana'><dt><dfn>nibbānagamana</dfn></dt><dd><p><span class='case'>mfn.</span> the going to nibbāna.</p></dd></dl>"
     },
     {
-        "word": "nibbānagamin",
+        "word": "nibbānagami",
         "text": "<dl id='nibbānagamin'><dt><dfn>nibbānagami(n)</dfn></dt><dd><p><span class='case'>mfn.</span> going to nibbāna.</p></dd></dl>"
     },
     {
-        "word": "nibbānagami",
-        "text": "<dl id='nibbānagami'><dt><dfn>nibbānagami(n)</dfn></dt><dd><p><span class='case'>mfn.</span> going to nibbāna.</p></dd></dl>"
+        "word": "nibbānagamin",
+        "text": "<dl id='nibbānagamin'><dt><dfn>nibbānagami(n)</dfn></dt><dd><p><span class='case'>mfn.</span> going to nibbāna.</p></dd></dl>"
     },
     {
         "word": "nibbānadhātu",
@@ -51972,12 +51972,12 @@
         "text": "<dl id='nibbānogadha'><dt><dfn>nibbānogadha</dfn></dt><dd><p><span class='case'>mfn.</span> having a firm footing in nibbana; or plunged into, immersed in nibbāna.</p></dd></dl>"
     },
     {
-        "word": "nibbānogadha-gāmin",
+        "word": "nibbānogadha-gāmi",
         "text": "<dl id='nibbānogadha-gāmin'><dt><dfn>nibbānogadha-gāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> leading to a firm footing in nibbāna.</p></dd></dl>"
     },
     {
-        "word": "nibbānogadha-gāmi",
-        "text": "<dl id='nibbānogadha-gāmi'><dt><dfn>nibbānogadha-gāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> leading to a firm footing in nibbāna.</p></dd></dl>"
+        "word": "nibbānogadha-gāmin",
+        "text": "<dl id='nibbānogadha-gāmin'><dt><dfn>nibbānogadha-gāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> leading to a firm footing in nibbāna.</p></dd></dl>"
     },
     {
         "word": "nibbāpana",
@@ -52021,1914 +52021,1918 @@
     },
     {
         "word": "nibbāyi",
-        "text": "<dl id='nibbāyi'><dt data-main-entry='nibbāyati'><dfn>nibbāyi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nibbāyati</span> (see <i><a href='/define/nibbāyati'>nibbāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbāyi'><dt data-main-entry='nibbāyati'><dfn>nibbāyi</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nibbāhati'>nibbāhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbāhapetva",
-        "text": "<dl id='nibbāhapetva'><dt><dfn>nibbāhapetva</dfn></dt><dd><p><span class='case'>absol.</span> having torn out; having plucked out.</p></dd></dl>"
+        "text": "<dl id='nibbāhapetva'><dt><dfn>nibbāhapetva</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nibbāhati'>nibbāhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbāhi",
-        "text": "<dl id='nibbāhi'><dt><dfn>nibbāhi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> having torn out; having plucked out.</p></dd></dl>"
+        "text": "<dl id='nibbāhi'><dt><dfn>nibbāhi</dfn></dt><dd><p><span class='case'>absol.</span> having torn out; having plucked out.</p></dd></dl>"
     },
     {
         "word": "nibbāhetvā",
-        "text": "<dl id='nibbāhetvā'><dt><dfn>nibbāhetvā</dfn></dt><dd><p><span class='case'>absol.</span> having been disheartened or disgusted.</p></dd></dl>"
+        "text": "<dl id='nibbāhetvā'><dt><dfn>nibbāhetvā</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> having torn out; having plucked out.</p></dd></dl>"
     },
     {
         "word": "nibbijja",
-        "text": "<dl id='nibbijja'><dt data-main-entry='nibbijjati'><dfn>nibbijja</dfn></dt><dd><p><span class='case'>absol. of nibbijjhati</span> (see <i><a href='/define/nibbijjhati'>nibbijjhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbijja'><dt data-main-entry='nibbijjati'><dfn>nibbijja</dfn></dt><dd><p><span class='case'>absol.</span> having been disheartened or disgusted.</p></dd></dl>"
     },
     {
         "word": "nibbhijjha",
-        "text": "<dl id='nibbhijjha'><dt><dfn>nibbhijjha</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>pieces through; strikes.</li><li>having penetrated?</li></ol></dd></dl>"
+        "text": "<dl id='nibbhijjha'><dt><dfn>nibbhijjha</dfn></dt><dd><p><span class='case'>absol. of nibbijjhati</span> (see <i><a href='/define/nibbijjhati'>nibbijjhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbijjhati",
-        "text": "<dl id='nibbijjhati'><dt data-main-entry='nibbijjhati'><dfn>nibbijjhati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbisati</span> (what is) paid; paid off; earned (see <i><a href='/define/nibbisati'>nibbisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbijjhati'><dt data-main-entry='nibbijjhati'><dfn>nibbijjhati</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>pieces through; strikes.</li><li>having penetrated?</li></ol></dd></dl>"
     },
     {
         "word": "nibbiṭṭha",
-        "text": "<dl id='nibbiṭṭha'><dt><dfn>nibbiṭṭha</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose service to the king had been recompensed or paid off; ?</p></dd></dl>"
+        "text": "<dl id='nibbiṭṭha'><dt><dfn>nibbiṭṭha</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbisati</span> (what is) paid; paid off; earned (see <i><a href='/define/nibbisati'>nibbisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbiṭṭharājabhaṭa",
-        "text": "<dl id='nibbiṭṭharājabhaṭa'><dt><dfn>nibbiṭṭharājabhaṭa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbinna'>nibbinna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbiṭṭharājabhaṭa'><dt><dfn>nibbiṭṭharājabhaṭa</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose service to the king had been recompensed or paid off; ?</p></dd></dl>"
     },
     {
         "word": "nibbiṇṇa",
-        "text": "<dl id='nibbiṇṇa'><dt><dfn>nibbiṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> weariness (of); disenchantment, dissatisfaction, disgust (with)</p></dd></dl>"
+        "text": "<dl id='nibbiṇṇa'><dt><dfn>nibbiṇṇa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbinna'>nibbinna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbidā",
-        "text": "<dl id='nibbidā'><dt><dfn>nibbidā</dfn></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li>(mfn.) being dissatisfied or disgusted; weary; turning away.</li><li>(m.) dissatisfaction; disgust; turning away.</li></ol></dd></dl>"
+        "text": "<dl id='nibbidā'><dt><dfn>nibbidā</dfn></dt><dd><p><span class='case'>pp mfn.</span> weariness (of); disenchantment, dissatisfaction, disgust (with)</p></dd></dl>"
     },
     {
         "word": "nibbinda",
-        "text": "<dl id='nibbinda'><dt><dfn>nibbinda</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbinda'><dt><dfn>nibbinda</dfn></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li>(mfn.) being dissatisfied or disgusted; weary; turning away.</li><li>(m.) dissatisfaction; disgust; turning away.</li></ol></dd></dl>"
     },
     {
         "word": "nibbindat",
-        "text": "<dl id='nibbindat'><dt><dfn>nibbinda(t)</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> is despondent; becomes wearied, fed up (with, loc., occasionally acc. or instr.), feels disenchantment or dissatisfaction or disgust (with, loc., occasionally acc. or instr.); gives up, turns away from (abl.)</p></dd></dl>"
+        "text": "<dl id='nibbindat'><dt><dfn>nibbinda(t)</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbindati",
-        "text": "<dl id='nibbindati'><dt data-main-entry='nibbindati'><dfn>nibbindati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbindati</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbindati'><dt data-main-entry='nibbindati'><dfn>nibbindati</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> is despondent; becomes wearied, fed up (with, loc., occasionally acc. or instr.), feels disenchantment or dissatisfaction or disgust (with, loc., occasionally acc. or instr.); gives up, turns away from (abl.)</p></dd></dl>"
     },
     {
         "word": "nibbindanta",
-        "text": "<dl id='nibbindanta'><dt><dfn>nibbindanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nibbindati</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbindanta'><dt><dfn>nibbindanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbindati</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbindamāna",
-        "text": "<dl id='nibbindamāna'><dt><dfn>nibbindamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> having got wearied of; having been disgusted with.</p></dd></dl>"
+        "text": "<dl id='nibbindamāna'><dt><dfn>nibbindamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nibbindati</span> (see <i><a href='/define/nibbindati'>nibbindati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbinditvā",
-        "text": "<dl id='nibbinditvā'><dt data-main-entry='nibbindati'><dfn>nibbinditvā</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>disenchanted or dissatisfied or disgusted (with); weary (of)</li><li>which has caused dissatisfaction or disgust; given up, turned away from.</li></ol></dd></dl>"
+        "text": "<dl id='nibbinditvā'><dt data-main-entry='nibbindati'><dfn>nibbinditvā</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> having got wearied of; having been disgusted with.</p></dd></dl>"
     },
     {
         "word": "nibbinna",
-        "text": "<dl id='nibbinna'><dt data-main-entry='nibbindati'><dfn>nibbinna</dfn></dt><dd><p><span class='case'>pp mfn.</span> very disgusted with; weary of.</p></dd></dl>"
+        "text": "<dl id='nibbinna'><dt data-main-entry='nibbindati'><dfn>nibbinna</dfn></dt><dd><p><span class='case'>absol.</span></p><ol type='1' class='decimal'><li>disenchanted or dissatisfied or disgusted (with); weary (of)</li><li>which has caused dissatisfaction or disgust; given up, turned away from.</li></ol></dd></dl>"
     },
     {
         "word": "nibbinnarūpa",
-        "text": "<dl id='nibbinnarūpa'><dt><dfn>nibbinnarūpa</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>earnings; wages.</li><li>expiation?</li></ol></dd></dl>"
+        "text": "<dl id='nibbinnarūpa'><dt><dfn>nibbinnarūpa</dfn></dt><dd><p><span class='case'>pp mfn.</span> very disgusted with; weary of.</p></dd></dl>"
     },
     {
         "word": "nibbisa",
-        "text": "<dl id='nibbisa'><dt><dfn>nibbisa</dfn></dt><dd><p><span class='case'>masculine</span> settles; earns; gains.</p></dd></dl>"
+        "text": "<dl id='nibbisa'><dt><dfn>nibbisa</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>earnings; wages.</li><li>expiation?</li></ol></dd></dl>"
     },
     {
         "word": "nibbisati",
-        "text": "<dl id='nibbisati'><dt data-main-entry='nibbisati'><dfn>nibbisati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbisati</span> (see <i><a href='/define/nibbisati'>nibbisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbisati'><dt data-main-entry='nibbisati'><dfn>nibbisati</dfn></dt><dd><p><span class='case'>masculine</span> settles; earns; gains.</p></dd></dl>"
     },
     {
         "word": "nibbisamāna",
-        "text": "<dl id='nibbisamāna'><dt><dfn>nibbisamāna</dfn></dt><dd><p><span class='case'>mfn.</span> wrestles.</p></dd></dl>"
+        "text": "<dl id='nibbisamāna'><dt><dfn>nibbisamāna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbisati</span> (see <i><a href='/define/nibbisati'>nibbisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbujjhati",
-        "text": "<dl id='nibbujjhati'><dt><dfn>nibbujjhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>ceased to burn, gone out; become cool, cooled; ceased.</li><li><ol type='i' class='lower-roman'><li>free from care or passion; serene, calm; happy; esp.</li><li>free from passion, in whom the fires of passion (the fuel for rebirth) have gone out.</li></ol></li><li>gone out (like a lamp or fire), ceased, dead (without the possibility of rebirth)</li></ol></dd></dl>"
+        "text": "<dl id='nibbujjhati'><dt><dfn>nibbujjhati</dfn></dt><dd><p><span class='case'>mfn.</span> wrestles.</p></dd></dl>"
     },
     {
         "word": "nibbuta",
-        "text": "<dl id='nibbuta'><dt data-main-entry='nibbāti'><dfn>nibbuta</dfn></dt><dd><p><span class='case'>mfn.</span> the ending of concerns and passions (and therefore of rebirth)</p></dd></dl>"
+        "text": "<dl id='nibbuta'><dt data-main-entry='nibbāti'><dfn>nibbuta</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>ceased to burn, gone out; become cool, cooled; ceased.</li><li><ol type='i' class='lower-roman'><li>free from care or passion; serene, calm; happy; esp.</li><li>free from passion, in whom the fires of passion (the fuel for rebirth) have gone out.</li></ol></li><li>gone out (like a lamp or fire), ceased, dead (without the possibility of rebirth)</li></ol></dd></dl>"
     },
     {
         "word": "nibbuti",
-        "text": "<dl id='nibbuti'><dt><dfn>nibbuti</dfn></dt><dd><p><span class='case'>feminine</span> wrestling; a wrestling match.</p></dd></dl>"
+        "text": "<dl id='nibbuti'><dt><dfn>nibbuti</dfn></dt><dd><p><span class='case'>mfn.</span> the ending of concerns and passions (and therefore of rebirth)</p></dd></dl>"
     },
     {
         "word": "nibbuddha",
-        "text": "<dl id='nibbuddha'><dt><dfn>nibbuddha</dfn></dt><dd><p><span class='case'>neuter</span> is led out; is carried out or away (see <i><a href='/define/nibbahati'>nibbahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbuddha'><dt><dfn>nibbuddha</dfn></dt><dd><p><span class='case'>feminine</span> wrestling; a wrestling match.</p></dd></dl>"
     },
     {
         "word": "nibbuyhati",
-        "text": "<dl id='nibbuyhati'><dt data-main-entry='nibbuyhati'><dfn>nibbuyhati</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nibbuyhati</span> (see <i><a href='/define/nibbuyhati'>nibbuyhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbuyhati'><dt data-main-entry='nibbuyhati'><dfn>nibbuyhati</dfn></dt><dd><p><span class='case'>neuter</span> is led out; is carried out or away (see <i><a href='/define/nibbahati'>nibbahati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbuyhamāna",
-        "text": "<dl id='nibbuyhamāna'><dt><dfn>nibbuyhamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/nivusita'>nivusita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbuyhamāna'><dt><dfn>nibbuyhamāna</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nibbuyhati</span> (see <i><a href='/define/nibbuyhati'>nibbuyhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbusita",
-        "text": "<dl id='nibbusita'><dt><dfn>nibbusita</dfn></dt><dd><p><span class='case'>pp mfn.</span> unwinding; disentanglement; rebuttal (one of the elements of a disputation)</p></dd></dl>"
+        "text": "<dl id='nibbusita'><dt><dfn>nibbusita</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/nivusita'>nivusita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbeṭhana",
-        "text": "<dl id='nibbeṭhana'><dt><dfn>nibbeṭhana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbeṭhana'><dt><dfn>nibbeṭhana</dfn></dt><dd><p><span class='case'>pp mfn.</span> unwinding; disentanglement; rebuttal (one of the elements of a disputation)</p></dd></dl>"
     },
     {
         "word": "nibbeṭhayati",
-        "text": "<dl id='nibbeṭhayati'><dt><dfn>nibbeṭhayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbeṭhayati'><dt><dfn>nibbeṭhayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbeṭhiyamāna",
-        "text": "<dl id='nibbeṭhiyamāna'><dt><dfn>nibbeṭhiyamāna</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbeṭhiyamāna'><dt><dfn>nibbeṭhiyamāna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbeṭhetabba",
-        "text": "<dl id='nibbeṭhetabba'><dt><dfn>nibbeṭhetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> unwinds (trans. and intrans.), disentangles; explicates; disentangles oneself; answers, rebuts (a charge)</p></dd></dl>"
+        "text": "<dl id='nibbeṭhetabba'><dt><dfn>nibbeṭhetabba</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbeṭheti",
-        "text": "<dl id='nibbeṭheti'><dt data-main-entry='nibbeṭheti'><dfn>nibbeṭheti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbeṭheti'><dt data-main-entry='nibbeṭheti'><dfn>nibbeṭheti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> unwinds (trans. and intrans.), disentangles; explicates; disentangles oneself; answers, rebuts (a charge)</p></dd></dl>"
     },
     {
         "word": "nibbeṭhenta",
-        "text": "<dl id='nibbeṭhenta'><dt><dfn>nibbeṭhenta</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> penetration; insight.</p></dd></dl>"
+        "text": "<dl id='nibbeṭhenta'><dt><dfn>nibbeṭhenta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nibbeṭheti</span> (see <i><a href='/define/nibbeṭheti'>nibbeṭheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nibbedha",
-        "text": "<dl id='nibbedha'><dt><dfn>nibbedha</dfn></dt><dd><p><span class='case'>masculine</span> belonging to, conducing to, penetration.</p></dd></dl>"
+        "text": "<dl id='nibbedha'><dt><dfn>nibbedha</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> penetration; insight.</p></dd></dl>"
     },
     {
         "word": "nibbedhabhāgiya",
-        "text": "<dl id='nibbedhabhāgiya'><dt><dfn>nibbedhabhāgiya</dfn></dt><dd><p><span class='case'>mfn.</span> piercing, penetrating.</p></dd></dl>"
+        "text": "<dl id='nibbedhabhāgiya'><dt><dfn>nibbedhabhāgiya</dfn></dt><dd><p><span class='case'>masculine</span> belonging to, conducing to, penetration.</p></dd></dl>"
     },
     {
         "word": "nibbedhika",
-        "text": "<dl id='nibbedhika'><dt><dfn>nibbedhika</dfn></dt><dd><p><span class='case'>mfn.</span> connected with recoiling; connected with despondency; giving up.</p></dd></dl>"
+        "text": "<dl id='nibbedhika'><dt><dfn>nibbedhika</dfn></dt><dd><p><span class='case'>mfn.</span> piercing, penetrating.</p></dd></dl>"
     },
     {
         "word": "nibbenjanīya",
-        "text": "<dl id='nibbenjanīya'><dt><dfn>nibbenjanīya</dfn></dt><dd><p><span class='case'>mfn.</span> not in doubt; certain, assured.</p></dd></dl>"
+        "text": "<dl id='nibbenjanīya'><dt><dfn>nibbenjanīya</dfn></dt><dd><p><span class='case'>mfn.</span> connected with recoiling; connected with despondency; giving up.</p></dd></dl>"
     },
     {
         "word": "nibbematika",
-        "text": "<dl id='nibbematika'><dt><dfn>nibbematika</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbisa'>nibbisa</a></i>)</p></dd></dl>"
+        "text": "<dl id='nibbematika'><dt><dfn>nibbematika</dfn></dt><dd><p><span class='case'>mfn.</span> not in doubt; certain, assured.</p></dd></dl>"
     },
     {
         "word": "nibbesa",
-        "text": "<dl id='nibbesa'><dt><dfn>nibbesa</dfn></dt><dd><p><span class='case'>masculine</span> invitation; a meal to which one is invited.</p></dd></dl>"
+        "text": "<dl id='nibbesa'><dt><dfn>nibbesa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nibbisa'>nibbisa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantana",
-        "text": "<dl id='nimantana'><dt><dfn>nimantana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantana'><dt><dfn>nimantana</dfn></dt><dd><p><span class='case'>masculine</span> invitation; a meal to which one is invited.</p></dd></dl>"
     },
     {
         "word": "nimantayati",
-        "text": "<dl id='nimantayati'><dt><dfn>nimantayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantayati'><dt><dfn>nimantayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantayi",
-        "text": "<dl id='nimantayi'><dt><dfn>nimantayi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nimanteti</span> invited (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantayi'><dt><dfn>nimantayi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantita",
-        "text": "<dl id='nimantita'><dt data-main-entry='nimanteti'><dfn>nimantita</dfn></dt><dd><p><span class='case'>pp mfn. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantita'><dt data-main-entry='nimanteti'><dfn>nimantita</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nimanteti</span> invited (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantiyamāna",
-        "text": "<dl id='nimantiyamāna'><dt><dfn>nimantiyamāna</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn. of nimantita</span> (see <i><a href='/define/nimantita'>nimantita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantiyamāna'><dt><dfn>nimantiyamāna</dfn></dt><dd><p><span class='case'>pp mfn. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantetabba",
-        "text": "<dl id='nimantetabba'><dt><dfn>nimantetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> calls, summons; invites (someone, acc.) to (instr.); offers, asks (someone) to accept (instr.)</p></dd></dl>"
+        "text": "<dl id='nimantetabba'><dt><dfn>nimantetabba</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn. of nimantita</span> (see <i><a href='/define/nimantita'>nimantita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimanteti",
-        "text": "<dl id='nimanteti'><dt data-main-entry='nimanteti'><dfn>nimanteti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimanteti'><dt data-main-entry='nimanteti'><dfn>nimanteti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> calls, summons; invites (someone, acc.) to (instr.); offers, asks (someone) to accept (instr.)</p></dd></dl>"
     },
     {
         "word": "nimantetvā",
-        "text": "<dl id='nimantetvā'><dt data-main-entry='nimanteti'><dfn>nimantetvā</dfn></dt><dd><p><span class='case'>absol. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimantetvā'><dt data-main-entry='nimanteti'><dfn>nimantetvā</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimantesi",
-        "text": "<dl id='nimantesi'><dt data-main-entry='nimanteti'><dfn>nimantesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>a sign or mark by which something or someone is recognized or identified or known or defined; a distinguishing mark or appearance; a perceived (enduring) attribute, predicate (especially that of permanence); an attribution.</li><li>the organ of generation (of either sex), the pudenda.</li></ol></li><li>an object or appearance or happening which is significant, which expresses more than itself; <ol type='i' class='lower-roman'><li>a sign, a significant appearance; an omen, a portent.</li><li>an indication, a hint.</li></ol></li><li><ol type='i' class='lower-roman'><li>what one notes or marks; an object of thought or meditation or concentration; an image.</li><li>an internal/ appearance or total awareness; a mental impression (appearing as an early stage of jhāna, a sign of progress)</li></ol></li><li>a ground, a cause, a reason.</li></ol></dd></dl>"
+        "text": "<dl id='nimantesi'><dt data-main-entry='nimanteti'><dfn>nimantesi</dfn></dt><dd><p><span class='case'>absol. of nimanteti</span> (see <i><a href='/define/nimanteti'>nimanteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimitta",
-        "text": "<dl id='nimitta'><dt><dfn>nimitta</dfn></dt><dd><p><span class='case'>masculine & neuter</span> makes a sign; marks; indicates; distinguishes.</p></dd></dl>"
+        "text": "<dl id='nimitta'><dt><dfn>nimitta</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>a sign or mark by which something or someone is recognized or identified or known or defined; a distinguishing mark or appearance; a perceived (enduring) attribute, predicate (especially that of permanence); an attribution.</li><li>the organ of generation (of either sex), the pudenda.</li></ol></li><li>an object or appearance or happening which is significant, which expresses more than itself; <ol type='i' class='lower-roman'><li>a sign, a significant appearance; an omen, a portent.</li><li>an indication, a hint.</li></ol></li><li><ol type='i' class='lower-roman'><li>what one notes or marks; an object of thought or meditation or concentration; an image.</li><li>an internal/ appearance or total awareness; a mental impression (appearing as an early stage of jhāna, a sign of progress)</li></ol></li><li>a ground, a cause, a reason.</li></ol></dd></dl>"
     },
     {
         "word": "nimittaṃ karoti",
-        "text": "<dl id='nimittaṃ karoti'><dt><dfn>nimittaṃ karoti</dfn></dt><dd><p>marks, apprehends the characteristic features; apprehends an object or appearance (as distinguished in various ways); distinguishes, identifies an object or appearance.</p></dd></dl>"
+        "text": "<dl id='nimittaṃ karoti'><dt><dfn>nimittaṃ karoti</dfn></dt><dd><p><span class='case'>masculine & neuter</span> makes a sign; marks; indicates; distinguishes.</p></dd></dl>"
     },
     {
         "word": "nimittaṃ gaṇhāti",
-        "text": "<dl id='nimittaṃ gaṇhāti'><dt><dfn>nimittaṃ gaṇhāti</dfn></dt><dd><p>apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics; exclusive concentration (on, loc.); being completely taken up (by, loc.)</p></dd></dl>"
-    },
-    {
-        "word": "nimittaggāha",
-        "text": "<dl id='nimittaggāha'><dt><dfn>nimitta(g)gāha</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
+        "text": "<dl id='nimittaṃ gaṇhāti'><dt><dfn>nimittaṃ gaṇhāti</dfn></dt><dd><p>marks, apprehends the characteristic features; apprehends an object or appearance (as distinguished in various ways); distinguishes, identifies an object or appearance.</p></dd></dl>"
     },
     {
         "word": "nimittagāha",
-        "text": "<dl id='nimittagāha'><dt><dfn>nimitta(g)gāha</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
+        "text": "<dl id='nimittaggāha'><dt><dfn>nimitta(g)gāha</dfn></dt><dd><p>apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics; exclusive concentration (on, loc.); being completely taken up (by, loc.)</p></dd></dl>"
     },
     {
-        "word": "nimittaggāhīn",
-        "text": "<dl id='nimittaggāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
-    },
-    {
-        "word": "nimittagāhīn",
-        "text": "<dl id='nimittagāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
-    },
-    {
-        "word": "nimittaggāhī",
-        "text": "<dl id='nimittaggāhī'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
+        "word": "nimittaggāha",
+        "text": "<dl id='nimittaggāha'><dt><dfn>nimitta(g)gāha</dfn></dt><dd><p>apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics; exclusive concentration (on, loc.); being completely taken up (by, loc.)</p></dd></dl>"
     },
     {
         "word": "nimittagāhī",
-        "text": "<dl id='nimittagāhī'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
+        "text": "<dl id='nimittaggāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
     },
     {
-        "word": "nimittanusārin",
-        "text": "<dl id='nimittanusārin'><dt><dfn>nimittanusāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> barter; exchange for.</p></dd></dl>"
+        "word": "nimittaggāhī",
+        "text": "<dl id='nimittaggāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
+    },
+    {
+        "word": "nimittagāhīn",
+        "text": "<dl id='nimittaggāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
+    },
+    {
+        "word": "nimittaggāhīn",
+        "text": "<dl id='nimittaggāhīn'><dt><dfn>nimitta(g)gāhī(n)</dfn></dt><dd><p><span class='case'>masculine</span> apprehending, responding emotionally to, an object or appearance; grasping, occupying oneself with, external features or characteristics.</p></dd></dl>"
     },
     {
         "word": "nimittanusāri",
-        "text": "<dl id='nimittanusāri'><dt><dfn>nimittanusāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> barter; exchange for.</p></dd></dl>"
+        "text": "<dl id='nimittanusārin'><dt><dfn>nimittanusāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
+    },
+    {
+        "word": "nimittanusārin",
+        "text": "<dl id='nimittanusārin'><dt><dfn>nimittanusāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> following attributes.</p></dd></dl>"
     },
     {
         "word": "nimissaṃ",
-        "text": "<dl id='nimissaṃ'><dt><dfn>nimissaṃ</dfn></dt><dd><p><span class='case'>1 sg.</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimissaṃ'><dt><dfn>nimissaṃ</dfn></dt><dd><p><span class='case'>mfn.</span> barter; exchange for.</p></dd></dl>"
     },
     {
         "word": "nimīlayati",
-        "text": "<dl id='nimīlayati'><dt><dfn>nimīlayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> closes; closes one’s eyes.</p></dd></dl>"
+        "text": "<dl id='nimīlayati'><dt><dfn>nimīlayati</dfn></dt><dd><p><span class='case'>1 sg.</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimīleti",
-        "text": "<dl id='nimīleti'><dt data-main-entry='nimīlati'><dfn>nimīleti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nimīleti</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimīleti'><dt data-main-entry='nimīlati'><dfn>nimīleti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> closes; closes one’s eyes.</p></dd></dl>"
     },
     {
         "word": "nimīletvā",
-        "text": "<dl id='nimīletvā'><dt data-main-entry='nimīlati'><dfn>nimīletvā</dfn></dt><dd><p><span class='case'>absol. of nimujjati</span> sunk down; plunged, immersed in; submerged (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimīletvā'><dt data-main-entry='nimīlati'><dfn>nimīletvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nimīleti</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimugga",
-        "text": "<dl id='nimugga'><dt data-main-entry='nimujjati'><dfn>nimugga</dfn></dt><dd><p><span class='case'>pp mfn.</span> sinks down; dives into, immerses oneself in; is submerged.</p></dd></dl>"
+        "text": "<dl id='nimugga'><dt data-main-entry='nimujjati'><dfn>nimugga</dfn></dt><dd><p><span class='case'>absol. of nimujjati</span> sunk down; plunged, immersed in; submerged (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimujjati",
-        "text": "<dl id='nimujjati'><dt data-main-entry='nimujjati'><dfn>nimujjati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimujjati'><dt data-main-entry='nimujjati'><dfn>nimujjati</dfn></dt><dd><p><span class='case'>pp mfn.</span> sinks down; dives into, immerses oneself in; is submerged.</p></dd></dl>"
     },
     {
         "word": "nimujjanta",
-        "text": "<dl id='nimujjanta'><dt><dfn>nimujjanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimujjanta'><dt><dfn>nimujjanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimujjituṃ",
-        "text": "<dl id='nimujjituṃ'><dt data-main-entry='nimujjati'><dfn>nimujjituṃ</dfn></dt><dd><p><span class='case'>inf. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimujjituṃ'><dt data-main-entry='nimujjati'><dfn>nimujjituṃ</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimujjitvā",
-        "text": "<dl id='nimujjitvā'><dt><dfn>nimujjitvā</dfn></dt><dd><p><span class='case'>absol.</span> release, deliverance.</p></dd></dl>"
+        "text": "<dl id='nimujjitvā'><dt><dfn>nimujjitvā</dfn></dt><dd><p><span class='case'>inf. of nimujjati</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimokkha",
-        "text": "<dl id='nimokkha'><dt><dfn>nimokkha</dfn></dt><dd><p><span class='case'>masculine</span> a leaf of the neem tree.</p></dd></dl>"
+        "text": "<dl id='nimokkha'><dt><dfn>nimokkha</dfn></dt><dd><p><span class='case'>absol.</span> release, deliverance.</p></dd></dl>"
     },
     {
         "word": "nimbapaṇṇa",
-        "text": "<dl id='nimbapaṇṇa'><dt><dfn>nimbapaṇṇa</dfn></dt><dd><p><span class='case'>neuter</span> a seed of the neem tree.</p></dd></dl>"
+        "text": "<dl id='nimbapaṇṇa'><dt><dfn>nimbapaṇṇa</dfn></dt><dd><p><span class='case'>masculine</span> a leaf of the neem tree.</p></dd></dl>"
     },
     {
         "word": "nimbabīja",
-        "text": "<dl id='nimbabīja'><dt><dfn>nimbabīja</dfn></dt><dd><p><span class='case'>neuter</span> rubs or wipes off.</p></dd></dl>"
+        "text": "<dl id='nimbabīja'><dt><dfn>nimbabīja</dfn></dt><dd><p><span class='case'>neuter</span> a seed of the neem tree.</p></dd></dl>"
     },
     {
         "word": "nimmajjati",
-        "text": "<dl id='nimmajjati'><dt><dfn>nimmajjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmajjati'><dt><dfn>nimmajjati</dfn></dt><dd><p><span class='case'>neuter</span> rubs or wipes off.</p></dd></dl>"
     },
     {
         "word": "nimmadayati",
-        "text": "<dl id='nimmadayati'><dt><dfn>nimmadayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> humbles; subdues.</p></dd></dl>"
+        "text": "<dl id='nimmadayati'><dt><dfn>nimmadayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmadeti",
-        "text": "<dl id='nimmadeti'><dt><dfn>nimmadeti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmināti</span> created (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmadeti'><dt><dfn>nimmadeti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> humbles; subdues.</p></dd></dl>"
     },
     {
         "word": "nimmāta",
-        "text": "<dl id='nimmāta'><dt><dfn>nimmāta</dfn></dt><dd><p><span class='case'>pp mfn.</span> the creator; maker; builder.</p></dd></dl>"
+        "text": "<dl id='nimmāta'><dt><dfn>nimmāta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmināti</span> created (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmātar",
-        "text": "<dl id='nimmātar'><dt><dfn>nimmātar</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmātar'><dt><dfn>nimmātar</dfn></dt><dd><p><span class='case'>pp mfn.</span> the creator; maker; builder.</p></dd></dl>"
     },
     {
         "word": "nimmādeti",
-        "text": "<dl id='nimmādeti'><dt><dfn>nimmādeti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmadeti</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmādeti'><dt><dfn>nimmādeti</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmādesi",
-        "text": "<dl id='nimmādesi'><dt><dfn>nimmādesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nimmānāyati'>nimmānāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmādesi'><dt><dfn>nimmādesi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmadeti</span> (see <i><a href='/define/nimmadeti'>nimmadeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmānayati",
-        "text": "<dl id='nimmānayati'><dt><dfn>nimmānayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>(mfn.) belonging to the nimmānarati devas.</li><li>(f.) the world of the nimmānarati devas.</li></ol></dd></dl>"
+        "text": "<dl id='nimmānayati'><dt><dfn>nimmānayati</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nimmānāyati'>nimmānāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmānarati",
-        "text": "<dl id='nimmānarati'><dt><dfn>nimmānarati</dfn></dt><dd><p><span class='case'>mfn. & feminine</span> the name of a group of devas.</p></dd></dl>"
+        "text": "<dl id='nimmānarati'><dt><dfn>nimmānarati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>(mfn.) belonging to the nimmānarati devas.</li><li>(f.) the world of the nimmānarati devas.</li></ol></dd></dl>"
     },
     {
         "word": "nimmānaratino",
-        "text": "<dl id='nimmānaratino'><dt><dfn>nimmānaratino</dfn></dt><dd><p><span class='case'>masculine plural</span> (see <i><a href='/define/nimmānarati'>nimmānarati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmānaratino'><dt><dfn>nimmānaratino</dfn></dt><dd><p><span class='case'>mfn. & feminine</span> the name of a group of devas.</p></dd></dl>"
     },
     {
         "word": "nimmānarāti",
-        "text": "<dl id='nimmānarāti'><dt><dfn>nimmānarāti</dfn></dt><dd><p><span class='case'>masculine plural</span> becomes humble, subdued; is humbled.</p></dd></dl>"
+        "text": "<dl id='nimmānarāti'><dt><dfn>nimmānarāti</dfn></dt><dd><p><span class='case'>masculine plural</span> (see <i><a href='/define/nimmānarati'>nimmānarati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmānāyati",
-        "text": "<dl id='nimmānāyati'><dt><dfn>nimmānāyati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmināti</span> formed, produced, created; (a form) created (by magic or supernatural power); a magical creation (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmānāyati'><dt><dfn>nimmānāyati</dfn></dt><dd><p><span class='case'>masculine plural</span> becomes humble, subdued; is humbled.</p></dd></dl>"
     },
     {
         "word": "nimmita",
-        "text": "<dl id='nimmita'><dt data-main-entry='nimmiṇāti'><dfn>nimmita</dfn></dt><dd><p><span class='case'>pp mfn & m.n.</span> produces, forms, creates (by magic or supernatural power)</p></dd></dl>"
+        "text": "<dl id='nimmita'><dt data-main-entry='nimmiṇāti'><dfn>nimmita</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nimmināti</span> formed, produced, created; (a form) created (by magic or supernatural power); a magical creation (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmināti",
-        "text": "<dl id='nimmināti'><dt><dfn>nimmināti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> produces, forms, creates (by magic or supernatural power)</p></dd></dl>"
+        "text": "<dl id='nimmināti'><dt><dfn>nimmināti</dfn></dt><dd><p><span class='case'>pp mfn & m.n.</span> produces, forms, creates (by magic or supernatural power)</p></dd></dl>"
     },
     {
         "word": "nimminitvā",
-        "text": "<dl id='nimminitvā'><dt><dfn>nimminitvā</dfn></dt><dd><p><span class='case'>absol. of nimmināti</span> (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimminitvā'><dt><dfn>nimminitvā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> produces, forms, creates (by magic or supernatural power)</p></dd></dl>"
     },
     {
         "word": "nimminitvāna",
-        "text": "<dl id='nimminitvāna'><dt><dfn>nimminitvāna</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimminitvāna'><dt><dfn>nimminitvāna</dfn></dt><dd><p><span class='case'>absol. of nimmināti</span> (see <i><a href='/define/nimmināti'>nimmināti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmīleti",
-        "text": "<dl id='nimmīleti'><dt><dfn>nimmīleti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nimīletvā'>nimīletvā</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmīleti'><dt><dfn>nimmīleti</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nimīleti'>nimīleti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmīletvā",
-        "text": "<dl id='nimmīletvā'><dt><dfn>nimmīletvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nimugga'>nimugga</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmīletvā'><dt><dfn>nimmīletvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nimīletvā'>nimīletvā</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmugga",
-        "text": "<dl id='nimmugga'><dt><dfn>nimmugga</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nimmugga'><dt><dfn>nimmugga</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nimugga'>nimugga</a></i>)</p></dd></dl>"
     },
     {
         "word": "nimmujjati",
-        "text": "<dl id='nimmujjati'><dt><dfn>nimmujjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> one’s own.</p></dd></dl>"
+        "text": "<dl id='nimmujjati'><dt><dfn>nimmujjati</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nimujjati'>nimujjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niya",
-        "text": "<dl id='niya'><dt><dfn>niya</dfn></dt><dd><p><span class='case'>mfn.</span> one’s own.</p></dd></dl>"
+        "text": "<dl id='niya'><dt><dfn>niya</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> one’s own.</p></dd></dl>"
     },
     {
         "word": "niyaka",
-        "text": "<dl id='niyaka'><dt><dfn>niyaka</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>constrained, bound; restrained; disciplined; constant.</li><li>(whose outcome or course is) determined, fixed; restricted, limited, specified; established, sure; inevitable, invariable.</li></ol></dd></dl>"
+        "text": "<dl id='niyaka'><dt><dfn>niyaka</dfn></dt><dd><p><span class='case'>mfn.</span> one’s own.</p></dd></dl>"
     },
     {
         "word": "niyata",
-        "text": "<dl id='niyata'><dt><dfn>niyata</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose lifetime is fixed.</p></dd></dl>"
+        "text": "<dl id='niyata'><dt><dfn>niyata</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>constrained, bound; restrained; disciplined; constant.</li><li>(whose outcome or course is) determined, fixed; restricted, limited, specified; established, sure; inevitable, invariable.</li></ol></dd></dl>"
     },
     {
         "word": "niyatāyuka",
-        "text": "<dl id='niyatāyuka'><dt><dfn>niyatāyuka</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyassa'>niyassa</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyatāyuka'><dt><dfn>niyatāyuka</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose lifetime is fixed.</p></dd></dl>"
     },
     {
         "word": "niyasa",
-        "text": "<dl id='niyasa'><dt><dfn>niyasa</dfn></dt><dd><p><span class='case'>mfn.</span> (a formal act of the <i>saṅgha</i>) conferring disgrace, loss of status; (or requiring effort)</p></dd></dl>"
+        "text": "<dl id='niyasa'><dt><dfn>niyasa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyassa'>niyassa</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyassa",
-        "text": "<dl id='niyassa'><dt><dfn>niyassa</dfn></dt><dd><p><span class='case'>mfn.</span> a formal niyassa act.</p></dd></dl>"
+        "text": "<dl id='niyassa'><dt><dfn>niyassa</dfn></dt><dd><p><span class='case'>mfn.</span> (a formal act of the <i>saṅgha</i>) conferring disgrace, loss of status; (or requiring effort)</p></dd></dl>"
     },
     {
         "word": "niyassaka",
-        "text": "<dl id='niyassaka'><dt><dfn>niyassaka</dfn></dt><dd><p><span class='case'>neuter</span> a formal act of the <i>saṅgha</i> conferring loss of status; disgracing, reprimanding.</p></dd></dl>"
+        "text": "<dl id='niyassaka'><dt><dfn>niyassaka</dfn></dt><dd><p><span class='case'>mfn.</span> a formal niyassa act.</p></dd></dl>"
     },
     {
         "word": "niyassakamma",
-        "text": "<dl id='niyassakamma'><dt><dfn>niyassakamma</dfn></dt><dd><p><span class='case'>neuter</span> dealt with by a formal act of the <i>saṅgha</i> conferring loss of status.</p></dd></dl>"
+        "text": "<dl id='niyassakamma'><dt><dfn>niyassakamma</dfn></dt><dd><p><span class='case'>neuter</span> a formal act of the <i>saṅgha</i> conferring loss of status; disgracing, reprimanding.</p></dd></dl>"
     },
     {
         "word": "niyassakammakata",
-        "text": "<dl id='niyassakammakata'><dt><dfn>niyassakammakata</dfn></dt><dd><p><span class='case'>mfn.</span> a fixed rule; a particular or specified way or manner; an invariable practice or experience; a determined or inevitable outcome, certainty; an assured state; what leads to an inevitable outcome, the way to an end.</p></dd></dl>"
+        "text": "<dl id='niyassakammakata'><dt><dfn>niyassakammakata</dfn></dt><dd><p><span class='case'>neuter</span> dealt with by a formal act of the <i>saṅgha</i> conferring loss of status.</p></dd></dl>"
     },
     {
         "word": "niyāma",
-        "text": "<dl id='niyāma'><dt><dfn>niyāma</dfn></dt><dd><p><span class='case'>masculine</span> the having an inevitable outcome; a state of certainty, an assured or determined state; a rule.</p></dd></dl>"
+        "text": "<dl id='niyāma'><dt><dfn>niyāma</dfn></dt><dd><p><span class='case'>mfn.</span> a fixed rule; a particular or specified way or manner; an invariable practice or experience; a determined or inevitable outcome, certainty; an assured state; what leads to an inevitable outcome, the way to an end.</p></dd></dl>"
     },
     {
         "word": "niyāmatā",
-        "text": "<dl id='niyāmatā'><dt><dfn>niyāmatā</dfn></dt><dd><p><span class='case'>feminine</span> yokes; ties; impels, directs; fixes the mind on.</p></dd></dl>"
+        "text": "<dl id='niyāmatā'><dt><dfn>niyāmatā</dfn></dt><dd><p><span class='case'>masculine</span> the having an inevitable outcome; a state of certainty, an assured or determined state; a rule.</p></dd></dl>"
     },
     {
         "word": "niyuñjati",
-        "text": "<dl id='niyuñjati'><dt data-main-entry='niyuñjati'><dfn>niyuñjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyūha'>niyyūha</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyuñjati'><dt data-main-entry='niyuñjati'><dfn>niyuñjati</dfn></dt><dd><p><span class='case'>feminine</span> yokes; ties; impels, directs; fixes the mind on.</p></dd></dl>"
     },
     {
         "word": "niyūha",
-        "text": "<dl id='niyūha'><dt><dfn>niyūha</dfn></dt><dd><p><span class='case'>masculine neuter</span> (see <i><a href='/define/niyojeti'>niyojeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyūha'><dt><dfn>niyūha</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyūha'>niyyūha</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyojayati",
-        "text": "<dl id='niyojayati'><dt><dfn>niyojayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nijoyeti</span> (see <i><a href='/define/niyojeti'>niyojeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyojayati'><dt><dfn>niyojayati</dfn></dt><dd><p><span class='case'>masculine neuter</span> (see <i><a href='/define/niyojeti'>niyojeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyojayi",
-        "text": "<dl id='niyojayi'><dt><dfn>niyojayi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> urges, directs to; incites; employs.</p></dd></dl>"
+        "text": "<dl id='niyojayi'><dt><dfn>niyojayi</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nijoyeti</span> (see <i><a href='/define/niyojeti'>niyojeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyojeti",
-        "text": "<dl id='niyojeti'><dt data-main-entry='niyuñjati'><dfn>niyojeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nīyati</span> (see <i><a href='/define/nīyati'>nīyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyojeti'><dt data-main-entry='niyuñjati'><dfn>niyojeti</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> urges, directs to; incites; employs.</p></dd></dl>"
     },
     {
         "word": "niyyati",
-        "text": "<dl id='niyyati'><dt data-main-entry='niyyāti'><dfn>niyyati</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg.</span> given; yielded.</p></dd></dl>"
+        "text": "<dl id='niyyati'><dt data-main-entry='niyyāti'><dfn>niyyati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nīyati</span> (see <i><a href='/define/nīyati'>nīyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyatta",
-        "text": "<dl id='niyyatta'><dt><dfn>niyyatta</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyatta'><dt><dfn>niyyatta</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg.</span> given; yielded.</p></dd></dl>"
     },
     {
         "word": "niyyanta",
-        "text": "<dl id='niyyanta'><dt><dfn>niyyanta</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n.</span> (see <i><a href='/define/nīyamāna'>nīyamāna</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyanta'><dt><dfn>niyyanta</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyamāna",
-        "text": "<dl id='niyyamāna'><dt><dfn>niyyamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāti</span> laid by; given, handed over; gone forth; gone away (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyamāna'><dt><dfn>niyyamāna</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n.</span> (see <i><a href='/define/nīyamāna'>nīyamāna</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāta",
-        "text": "<dl id='niyyāta'><dt><dfn>niyyāta</dfn></dt><dd><p><span class='case'>pp mfn.</span> one who leaves (<i>saṃsara</i>)</p></dd></dl>"
+        "text": "<dl id='niyyāta'><dt><dfn>niyyāta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāti</span> laid by; given, handed over; gone forth; gone away (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyātar",
-        "text": "<dl id='niyyātar'><dt data-main-entry='niyyāti'><dfn>niyyāta(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyātar'><dt data-main-entry='niyyāti'><dfn>niyyāta(r)</dfn></dt><dd><p><span class='case'>pp mfn.</span> one who leaves (<i>saṃsara</i>)</p></dd></dl>"
     },
     {
         "word": "niyyātayati",
-        "text": "<dl id='niyyātayati'><dt><dfn>niyyātayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> goes out, goes forth (to); leaves; esp. leaves <i>saṃsara</i>.</p></dd></dl>"
+        "text": "<dl id='niyyātayati'><dt><dfn>niyyātayati</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāti",
-        "text": "<dl id='niyyāti'><dt data-main-entry='niyyāti'><dfn>niyyāti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāteti</span> handed back, restored; handed over, entrusted; given (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāti'><dt data-main-entry='niyyāti'><dfn>niyyāti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> goes out, goes forth (to); leaves; esp. leaves <i>saṃsara</i>.</p></dd></dl>"
     },
     {
         "word": "niyyātita",
-        "text": "<dl id='niyyātita'><dt data-main-entry='niyyāteti'><dfn>niyyātita</dfn></dt><dd><p><span class='case'>pp mfn. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyātita'><dt data-main-entry='niyyāteti'><dfn>niyyātita</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāteti</span> handed back, restored; handed over, entrusted; given (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyātuṃ",
-        "text": "<dl id='niyyātuṃ'><dt><dfn>niyyātuṃ</dfn></dt><dd><p><span class='case'>inf. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyātuṃ'><dt><dfn>niyyātuṃ</dfn></dt><dd><p><span class='case'>pp mfn. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyātetabba",
-        "text": "<dl id='niyyātetabba'><dt><dfn>niyyātetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span></p><ol type='1' class='decimal'><li>hands back; restores; pays back.</li><li>hands over (ownership or responsibility); entrusts; gives (formally), dedicates.</li></ol></dd></dl>"
+        "text": "<dl id='niyyātetabba'><dt><dfn>niyyātetabba</dfn></dt><dd><p><span class='case'>inf. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāteti",
-        "text": "<dl id='niyyāteti'><dt data-main-entry='niyyāteti'><dfn>niyyāteti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāteti'><dt data-main-entry='niyyāteti'><dfn>niyyāteti</dfn></dt><dd><p><span class='case'>fpp mfn.</span></p><ol type='1' class='decimal'><li>hands back; restores; pays back.</li><li>hands over (ownership or responsibility); entrusts; gives (formally), dedicates.</li></ol></dd></dl>"
     },
     {
         "word": "niyyātetvā",
-        "text": "<dl id='niyyātetvā'><dt data-main-entry='niyyāteti'><dfn>niyyātetvā</dfn></dt><dd><p><span class='case'>absol. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyātetvā'><dt data-main-entry='niyyāteti'><dfn>niyyātetvā</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyātesi",
-        "text": "<dl id='niyyātesi'><dt data-main-entry='niyyāteti'><dfn>niyyātesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyātesi'><dt data-main-entry='niyyāteti'><dfn>niyyātesi</dfn></dt><dd><p><span class='case'>absol. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādayati",
-        "text": "<dl id='niyyādayati'><dt><dfn>niyyādayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyātita'>niyyātita</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādayati'><dt><dfn>niyyādayati</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādita",
-        "text": "<dl id='niyyādita'><dt data-main-entry='niyyādeti'><dfn>niyyādita</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādita'><dt data-main-entry='niyyādeti'><dfn>niyyādita</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyātita'>niyyātita</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādeti",
-        "text": "<dl id='niyyādeti'><dt data-main-entry='niyyādeti'><dfn>niyyādeti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyātetabba'>niyyātetabba</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādeti'><dt data-main-entry='niyyādeti'><dfn>niyyādeti</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādetabba",
-        "text": "<dl id='niyyādetabba'><dt><dfn>niyyādetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādetabba'><dt><dfn>niyyādetabba</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niyyātetabba'>niyyātetabba</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādetuṃ",
-        "text": "<dl id='niyyādetuṃ'><dt><dfn>niyyādetuṃ</dfn></dt><dd><p><span class='case'>inf.</span> (see <i><a href='/define/niyyātetvā'>niyyātetvā</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādetuṃ'><dt><dfn>niyyādetuṃ</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādetvā",
-        "text": "<dl id='niyyādetvā'><dt data-main-entry='niyyādeti'><dfn>niyyādetvā</dfn></dt><dd><p><span class='case'>absol. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyādetvā'><dt data-main-entry='niyyādeti'><dfn>niyyādetvā</dfn></dt><dd><p><span class='case'>inf.</span> (see <i><a href='/define/niyyātetvā'>niyyātetvā</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyādesi",
-        "text": "<dl id='niyyādesi'><dt data-main-entry='niyyādeti'><dfn>niyyādesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> going out, setting forth; (the way of) getting out, leaving (<i>saṃsāra</i>)</p></dd></dl>"
+        "text": "<dl id='niyyādesi'><dt data-main-entry='niyyādeti'><dfn>niyyādesi</dfn></dt><dd><p><span class='case'>absol. of niyyāteti</span> (see <i><a href='/define/niyyāteti'>niyyāteti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāna",
-        "text": "<dl id='niyyāna'><dt><dfn>niyyāna</dfn></dt><dd><p><span class='case'>neuter</span> going out, setting forth; being a good way, leading to good; conducive to leaving (<i>saṃsāra</i>)</p></dd></dl>"
+        "text": "<dl id='niyyāna'><dt><dfn>niyyāna</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> going out, setting forth; (the way of) getting out, leaving (<i>saṃsāra</i>)</p></dd></dl>"
     },
     {
         "word": "niyyānika",
-        "text": "<dl id='niyyānika'><dt><dfn>niyyānika</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyānika'><dt><dfn>niyyānika</dfn></dt><dd><p><span class='case'>neuter</span> going out, setting forth; being a good way, leading to good; conducive to leaving (<i>saṃsāra</i>)</p></dd></dl>"
     },
     {
         "word": "niyyāyati",
-        "text": "<dl id='niyyāyati'><dt><dfn>niyyāyati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāyati'><dt><dfn>niyyāyati</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāyanta",
-        "text": "<dl id='niyyāyanta'><dt><dfn>niyyāyanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāyanta'><dt><dfn>niyyāyanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāsi",
-        "text": "<dl id='niyyāsi'><dt data-main-entry='niyyāti'><dfn>niyyāsi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāsi'><dt data-main-entry='niyyāti'><dfn>niyyāsi</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyāsuṃ",
-        "text": "<dl id='niyyāsuṃ'><dt><dfn>niyyāsuṃ</dfn></dt><dd><p><span class='case'>3 pl. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niyyāsuṃ'><dt><dfn>niyyāsuṃ</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyiṃsu",
-        "text": "<dl id='niyyiṃsu'><dt><dfn>niyyiṃsu</dfn></dt><dd><p><span class='case'>3 pl.</span> a projection, a projecting room; a pinnacle, a turret.</p></dd></dl>"
+        "text": "<dl id='niyyiṃsu'><dt><dfn>niyyiṃsu</dfn></dt><dd><p><span class='case'>3 pl. of niyyāti</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niyyūha",
-        "text": "<dl id='niyyūha'><dt><dfn>niyyūha</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niraṅkaroti'>niraṅkaroti</a></i>).</p></dd></dl>"
+        "text": "<dl id='niyyūha'><dt><dfn>niyyūha</dfn></dt><dd><p><span class='case'>3 pl.</span> a projection, a projecting room; a pinnacle, a turret.</p></dd></dl>"
     },
     {
         "word": "niraṃkaroti",
-        "text": "<dl id='niraṃkaroti'><dt><dfn>niraṃkaroti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> went out; left; came out, emerged, appeared.</p></dd></dl>"
+        "text": "<dl id='niraṃkaroti'><dt><dfn>niraṃkaroti</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/niraṅkaroti'>niraṅkaroti</a></i>).</p></dd></dl>"
     },
     {
         "word": "niragamā",
-        "text": "<dl id='niragamā'><dt><dfn>niragamā</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niraṅkaroti</span> repudiated, rejected; removed (see <i><a href='/define/niraṅkaroti'>niraṅkaroti</a></i>).</p></dd></dl>"
+        "text": "<dl id='niragamā'><dt><dfn>niragamā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> went out; left; came out, emerged, appeared.</p></dd></dl>"
     },
     {
         "word": "niraṅkata",
-        "text": "<dl id='niraṅkata'><dt data-main-entry='niraṅkaroti'><dfn>niraṅkata</dfn></dt><dd><p><span class='case'>pp mfn.</span> separates oneself from; repudiates; rejects; removes.</p></dd></dl>"
+        "text": "<dl id='niraṅkata'><dt data-main-entry='niraṅkaroti'><dfn>niraṅkata</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niraṅkaroti</span> repudiated, rejected; removed (see <i><a href='/define/niraṅkaroti'>niraṅkaroti</a></i>).</p></dd></dl>"
     },
     {
         "word": "niraṅkaroti",
-        "text": "<dl id='niraṅkaroti'><dt data-main-entry='niraṅkaroti'><dfn>niraṅkaroti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> delighting in; attached, devoted to; intent upon.</p></dd></dl>"
+        "text": "<dl id='niraṅkaroti'><dt data-main-entry='niraṅkaroti'><dfn>niraṅkaroti</dfn></dt><dd><p><span class='case'>pp mfn.</span> separates oneself from; repudiates; rejects; removes.</p></dd></dl>"
     },
     {
         "word": "nirata",
-        "text": "<dl id='nirata'><dt><dfn>nirata</dfn></dt><dd><p><span class='case'>mfn.</span> the lack of an enduring self; ? the letting go (of an enduring self); ?</p></dd></dl>"
+        "text": "<dl id='nirata'><dt><dfn>nirata</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> delighting in; attached, devoted to; intent upon.</p></dd></dl>"
     },
     {
         "word": "niratta",
-        "text": "<dl id='niratta'><dt><dfn>niratta</dfn><sup>1</sup></dt><dd><p><span class='case'>neuter</span> thrown off; let go (see <i><a href='/define/nirassati'>nirassati</a></i>).</p></dd><dt><dfn>niratta</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/niratta'>niratta</a></i>).</p></dd></dl>"
+        "text": "<dl id='niratta'><dt><dfn>niratta</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn.</span> the lack of an enduring self; ? the letting go (of an enduring self); ?</p></dd><dt><dfn>niratta</dfn><sup>2</sup></dt><dd><p><span class='case'>neuter</span> thrown off; let go (see <i><a href='/define/nirassati'>nirassati</a></i>).</p></dd></dl>"
     },
     {
         "word": "nirattan",
-        "text": "<dl id='nirattan'><dt><dfn>niratta(n)</dfn></dt><dd><p><span class='case'>masculine</span> unprofitable; useless; meaningless.</p></dd></dl>"
+        "text": "<dl id='nirattan'><dt><dfn>niratta(n)</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/niratta'>niratta</a></i>).</p></dd></dl>"
     },
     {
         "word": "niratthaka",
-        "text": "<dl id='niratthaka'><dt><dfn>niratthaka</dfn></dt><dd><p><span class='case'>mf(~ā, ~ikā)n.</span> useless; to no purpose.</p></dd></dl>"
+        "text": "<dl id='niratthaka'><dt><dfn>niratthaka</dfn></dt><dd><p><span class='case'>masculine</span> unprofitable; useless; meaningless.</p></dd></dl>"
     },
     {
         "word": "niratthakaṃ",
-        "text": "<dl id='niratthakaṃ'><dt><dfn>niratthakaṃ</dfn></dt><dd><p><span class='case'>adverb</span> free from (latent) disposition.</p></dd></dl>"
+        "text": "<dl id='niratthakaṃ'><dt><dfn>niratthakaṃ</dfn></dt><dd><p><span class='case'>mf(~ā, ~ikā)n.</span> useless; to no purpose.</p></dd></dl>"
     },
     {
         "word": "niranusaya",
-        "text": "<dl id='niranusaya'><dt><dfn>niranusaya</dfn></dt><dd><p><span class='case'>mfn.</span> free from (latent) disposition.</p></dd></dl>"
+        "text": "<dl id='niranusaya'><dt><dfn>niranusaya</dfn></dt><dd><p><span class='case'>adverb</span> free from (latent) disposition.</p></dd></dl>"
     },
     {
         "word": "nirabbuda",
-        "text": "<dl id='nirabbuda'><dt><dfn>nirabbuda</dfn></dt><dd><p><span class='case'>n.m.</span> a place or state of punishment and torture (after death); hell, a hell.</p></dd></dl>"
+        "text": "<dl id='nirabbuda'><dt><dfn>nirabbuda</dfn></dt><dd><p><span class='case'>mfn.</span> free from (latent) disposition.</p></dd></dl>"
     },
     {
         "word": "niraya",
-        "text": "<dl id='niraya'><dt><dfn>niraya</dfn></dt><dd><p><span class='case'>masculine</span> leading to hell.</p></dd></dl>"
+        "text": "<dl id='niraya'><dt><dfn>niraya</dfn></dt><dd><p><span class='case'>n.m.</span> a place or state of punishment and torture (after death); hell, a hell.</p></dd></dl>"
     },
     {
         "word": "nirayagāmanīya",
-        "text": "<dl id='nirayagāmanīya'><dt><dfn>nirayagāmanīya</dfn></dt><dd><p><span class='case'>mfn.</span> going to hell.</p></dd></dl>"
-    },
-    {
-        "word": "nirayagāmin",
-        "text": "<dl id='nirayagāmin'><dt><dfn>nirayagāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> a guard, a torturer in hell.</p></dd></dl>"
+        "text": "<dl id='nirayagāmanīya'><dt><dfn>nirayagāmanīya</dfn></dt><dd><p><span class='case'>masculine</span> leading to hell.</p></dd></dl>"
     },
     {
         "word": "nirayagāmi",
-        "text": "<dl id='nirayagāmi'><dt><dfn>nirayagāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> a guard, a torturer in hell.</p></dd></dl>"
+        "text": "<dl id='nirayagāmin'><dt><dfn>nirayagāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> going to hell.</p></dd></dl>"
+    },
+    {
+        "word": "nirayagāmin",
+        "text": "<dl id='nirayagāmin'><dt><dfn>nirayagāmi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> going to hell.</p></dd></dl>"
     },
     {
         "word": "nirayapāla",
-        "text": "<dl id='nirayapāla'><dt><dfn>nirayapāla</dfn></dt><dd><p><span class='case'>masculine</span> lets go.</p></dd></dl>"
+        "text": "<dl id='nirayapāla'><dt><dfn>nirayapāla</dfn></dt><dd><p><span class='case'>mfn.</span> a guard, a torturer in hell.</p></dd></dl>"
     },
     {
         "word": "nirassajati",
-        "text": "<dl id='nirassajati'><dt><dfn>nirassajati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> throws off; lets go; drives away.</p></dd></dl>"
+        "text": "<dl id='nirassajati'><dt><dfn>nirassajati</dfn></dt><dd><p><span class='case'>masculine</span> lets go.</p></dd></dl>"
     },
     {
         "word": "nirassati",
-        "text": "<dl id='nirassati'><dt><dfn>nirassati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niraṅkata</span> (see <i><a href='/define/niraṅkata'>niraṅkata</a></i>)</p></dd></dl>"
+        "text": "<dl id='nirassati'><dt><dfn>nirassati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> throws off; lets go; drives away.</p></dd></dl>"
     },
     {
         "word": "nirākata",
-        "text": "<dl id='nirākata'><dt data-main-entry='nirākaroti'><dfn>nirākata</dfn></dt><dd><p><span class='case'>pp mfn.</span> without killing; free from slaughter.</p></dd></dl>"
+        "text": "<dl id='nirākata'><dt data-main-entry='nirākaroti'><dfn>nirākata</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niraṅkata</span> (see <i><a href='/define/niraṅkata'>niraṅkata</a></i>)</p></dd></dl>"
     },
     {
         "word": "nirārambha",
-        "text": "<dl id='nirārambha'><dt><dfn>nirārambha</dfn></dt><dd><p><span class='case'>mfn.</span> without desire; without expectation.</p></dd></dl>"
+        "text": "<dl id='nirārambha'><dt><dfn>nirārambha</dfn></dt><dd><p><span class='case'>pp mfn.</span> without killing; free from slaughter.</p></dd></dl>"
     },
     {
         "word": "nirāsasa",
-        "text": "<dl id='nirāsasa'><dt><dfn>nirāsasa</dfn></dt><dd><p><span class='case'>mfn.</span> without desire; without expecatation.</p></dd></dl>"
+        "text": "<dl id='nirāsasa'><dt><dfn>nirāsasa</dfn></dt><dd><p><span class='case'>mfn.</span> without desire; without expectation.</p></dd></dl>"
     },
     {
         "word": "nirāsāsa",
-        "text": "<dl id='nirāsāsa'><dt><dfn>nirāsāsa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nirāsasa'>nirāsasa</a></i>)</p></dd></dl>"
+        "text": "<dl id='nirāsāsa'><dt><dfn>nirāsāsa</dfn></dt><dd><p><span class='case'>mfn.</span> without desire; without expecatation.</p></dd></dl>"
     },
     {
         "word": "nirujjhati",
-        "text": "<dl id='nirujjhati'><dt data-main-entry='nirujjhati'><dfn>nirujjhati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nirujjhati</span> (see <i><a href='/define/nirujjhati'>nirujjhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nirujjhati'><dt data-main-entry='nirujjhati'><dfn>nirujjhati</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nirāsasa'>nirāsasa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nirujjhamāna",
-        "text": "<dl id='nirujjhamāna'><dt><dfn>nirujjhamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> an expression; a form of words; a way of speaking; an alternative terminology, a gloss.</p></dd></dl>"
+        "text": "<dl id='nirujjhamāna'><dt><dfn>nirujjhamāna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nirujjhati</span> (see <i><a href='/define/nirujjhati'>nirujjhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nirutti",
-        "text": "<dl id='nirutti'><dt><dfn>nirutti</dfn></dt><dd><p><span class='case'>feminine</span> analytic knowledge or understanding of the form of words, of expressions.</p></dd></dl>"
+        "text": "<dl id='nirutti'><dt><dfn>nirutti</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> an expression; a form of words; a way of speaking; an alternative terminology, a gloss.</p></dd></dl>"
     },
     {
         "word": "niruttipaṭisambhidā",
-        "text": "<dl id='niruttipaṭisambhidā'><dt><dfn>niruttipaṭisambhidā</dfn></dt><dd><p><span class='case'>feminine, ~a, neuter</span> a way of speaking; an expression; (merely using an expression; ?)</p></dd></dl>"
+        "text": "<dl id='niruttipaṭisambhidā'><dt><dfn>niruttipaṭisambhidā</dfn></dt><dd><p><span class='case'>feminine</span> analytic knowledge or understanding of the form of words, of expressions.</p></dd></dl>"
     },
     {
         "word": "niruttipatha",
-        "text": "<dl id='niruttipatha'><dt><dfn>niruttipatha</dfn></dt><dd><p><span class='case'>masculine</span> ceased; no more (see <i><a href='/define/nirujjhati'>nirujjhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='niruttipatha'><dt><dfn>niruttipatha</dfn></dt><dd><p><span class='case'>feminine, ~a, neuter</span> a way of speaking; an expression; (merely using an expression; ?)</p></dd></dl>"
     },
     {
         "word": "niruddha",
-        "text": "<dl id='niruddha'><dt data-main-entry='nirujjhati'><dfn>niruddha</dfn></dt><dd><p><span class='case'>pp mfn.</span> free from attachments; free from belongings.</p></dd></dl>"
+        "text": "<dl id='niruddha'><dt data-main-entry='nirujjhati'><dfn>niruddha</dfn></dt><dd><p><span class='case'>masculine</span> ceased; no more (see <i><a href='/define/nirujjhati'>nirujjhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nirupadhika",
-        "text": "<dl id='nirupadhika'><dt><dfn>nirupadhika</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>ceasing, cessation; the being no more; stopping, shutting off.</li><li>(for saññāvedayitanirodha) the cessation of conception and feeling.</li></ol></dd></dl>"
+        "text": "<dl id='nirupadhika'><dt><dfn>nirupadhika</dfn></dt><dd><p><span class='case'>pp mfn.</span> free from attachments; free from belongings.</p></dd></dl>"
     },
     {
         "word": "nirodha",
-        "text": "<dl id='nirodha'><dt><dfn>nirodha</dfn></dt><dd><p><span class='case'>masculine</span> cessation; obstructing, making cease.</p></dd></dl>"
+        "text": "<dl id='nirodha'><dt><dfn>nirodha</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>ceasing, cessation; the being no more; stopping, shutting off.</li><li>(for saññāvedayitanirodha) the cessation of conception and feeling.</li></ol></dd></dl>"
     },
     {
         "word": "nirodhana",
-        "text": "<dl id='nirodhana'><dt><dfn>nirodhana</dfn></dt><dd><p><span class='case'>mfn.</span> liable to cessation; inevitably ceasing.</p></dd></dl>"
+        "text": "<dl id='nirodhana'><dt><dfn>nirodhana</dfn></dt><dd><p><span class='case'>masculine</span> cessation; obstructing, making cease.</p></dd></dl>"
     },
     {
         "word": "nirodhadhamma",
-        "text": "<dl id='nirodhadhamma'><dt><dfn>nirodhadhamma</dfn></dt><dd><p><span class='case'>mfn.</span> destroying; dissolving; annihilating.</p></dd></dl>"
+        "text": "<dl id='nirodhadhamma'><dt><dfn>nirodhadhamma</dfn></dt><dd><p><span class='case'>mfn.</span> liable to cessation; inevitably ceasing.</p></dd></dl>"
     },
     {
         "word": "nirodhetabba",
-        "text": "<dl id='nirodhetabba'><dt><dfn>nirodhetabba</dfn></dt><dd><p><span class='case'>fpp (mf)n.</span> having destroyed; having dissolved; having annihilated.</p></dd></dl>"
+        "text": "<dl id='nirodhetabba'><dt><dfn>nirodhetabba</dfn></dt><dd><p><span class='case'>mfn.</span> destroying; dissolving; annihilating.</p></dd></dl>"
     },
     {
         "word": "nirodhetvā",
-        "text": "<dl id='nirodhetvā'><dt data-main-entry='nirodheti'><dfn>nirodhetvā</dfn></dt><dd><p><span class='case'>absol. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nirodhetvā'><dt data-main-entry='nirodheti'><dfn>nirodhetvā</dfn></dt><dd><p><span class='case'>fpp (mf)n.</span> having destroyed; having dissolved; having annihilated.</p></dd></dl>"
     },
     {
         "word": "nilacchita",
-        "text": "<dl id='nilacchita'><dt><dfn>nilacchita</dfn></dt><dd><p><span class='case'>pp mfn.</span> castrates; marks.</p></dd></dl>"
+        "text": "<dl id='nilacchita'><dt><dfn>nilacchita</dfn></dt><dd><p><span class='case'>absol. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nilaccheti",
-        "text": "<dl id='nilaccheti'><dt><dfn>nilaccheti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nillaccheti</span> (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nilaccheti'><dt><dfn>nilaccheti</dfn></dt><dd><p><span class='case'>pp mfn.</span> castrates; marks.</p></dd></dl>"
     },
     {
         "word": "nilacchesi",
-        "text": "<dl id='nilacchesi'><dt><dfn>nilacchesi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nilacchesi'><dt><dfn>nilacchesi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nillaccheti</span> (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niluñchita",
-        "text": "<dl id='niluñchita'><dt><dfn>niluñchita</dfn></dt><dd><p><span class='case'>pp mfn.</span> who has alighted on, settled on; perched; keeping apart; hidden; lurking, lying in wait.</p></dd></dl>"
+        "text": "<dl id='niluñchita'><dt><dfn>niluñchita</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nilīna",
-        "text": "<dl id='nilīna'><dt data-main-entry='nilīyati'><dfn>nilīna</dfn></dt><dd><p><span class='case'>pp mfn. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nilīna'><dt data-main-entry='nilīyati'><dfn>nilīna</dfn></dt><dd><p><span class='case'>pp mfn.</span> who has alighted on, settled on; perched; keeping apart; hidden; lurking, lying in wait.</p></dd></dl>"
     },
     {
         "word": "nillacchita",
-        "text": "<dl id='nillacchita'><dt><dfn>nillacchita</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillacchita'><dt><dfn>nillacchita</dfn></dt><dd><p><span class='case'>pp mfn. of nillaccheti</span> castrated (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nillaccheti",
-        "text": "<dl id='nillaccheti'><dt><dfn>nillaccheti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nilacchesi'>nilacchesi</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillaccheti'><dt><dfn>nillaccheti</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nillaccheti'>nillaccheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nillacchesi",
-        "text": "<dl id='nillacchesi'><dt><dfn>nillacchesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> having wagged (the tongue); having moved the tongue to and fro.</p></dd></dl>"
+        "text": "<dl id='nillacchesi'><dt><dfn>nillacchesi</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nilacchesi'>nilacchesi</a></i>)</p></dd></dl>"
     },
     {
         "word": "nillāletvā",
-        "text": "<dl id='nillāletvā'><dt><dfn>nillāletvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nillāḷetvā'>nillāḷetvā</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillāletvā'><dt><dfn>nillāletvā</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> having wagged (the tongue); having moved the tongue to and fro.</p></dd></dl>"
     },
     {
         "word": "nillāḷetvā",
-        "text": "<dl id='nillāḷetvā'><dt><dfn>nillāḷetvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nīlī'>nīlī</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillāḷetvā'><dt><dfn>nillāḷetvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nillāḷetvā'>nillāḷetvā</a></i>)</p></dd></dl>"
     },
     {
         "word": "nillī",
-        "text": "<dl id='nillī'><dt><dfn>nillī</dfn></dt><dd><p><span class='case'>feminine</span> having licked, licked of; having took up with the finger.</p></dd></dl>"
+        "text": "<dl id='nillī'><dt><dfn>nillī</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nīlī'>nīlī</a></i>)</p></dd></dl>"
     },
     {
         "word": "nillehitvā",
-        "text": "<dl id='nillehitvā'><dt><dfn>nillehitvā</dfn></dt><dd><p><span class='case'>absol. of nilloketi</span> (see <i><a href='/define/nilloketi'>nilloketi</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillehitvā'><dt><dfn>nillehitvā</dfn></dt><dd><p><span class='case'>feminine</span> having licked, licked of; having took up with the finger.</p></dd></dl>"
     },
     {
         "word": "nilloketabba",
-        "text": "<dl id='nilloketabba'><dt><dfn>nilloketabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> observes; looks at carefully; examines.</p></dd></dl>"
+        "text": "<dl id='nilloketabba'><dt><dfn>nilloketabba</dfn></dt><dd><p><span class='case'>absol. of nilloketi</span> (see <i><a href='/define/nilloketi'>nilloketi</a></i>)</p></dd></dl>"
     },
     {
         "word": "nilloketi",
-        "text": "<dl id='nilloketi'><dt data-main-entry='nilloketi'><dfn>nilloketi</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> plunder.</p></dd></dl>"
+        "text": "<dl id='nilloketi'><dt data-main-entry='nilloketi'><dfn>nilloketi</dfn></dt><dd><p><span class='case'>fpp mfn.</span> observes; looks at carefully; examines.</p></dd></dl>"
     },
     {
         "word": "nillopa",
-        "text": "<dl id='nillopa'><dt><dfn>nillopa</dfn></dt><dd><p><span class='case'>masculine</span> gone or come back, returned, turned back; turned away from, giving up; ceased (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nillopa'><dt><dfn>nillopa</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> plunder.</p></dd></dl>"
     },
     {
         "word": "nivatta",
-        "text": "<dl id='nivatta'><dt data-main-entry='nivattati'><dfn>nivatta</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose seed is inoperative?</p></dd></dl>"
+        "text": "<dl id='nivatta'><dt data-main-entry='nivattati'><dfn>nivatta</dfn></dt><dd><p><span class='case'>masculine</span> gone or come back, returned, turned back; turned away from, giving up; ceased (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivattabīja",
-        "text": "<dl id='nivattabīja'><dt><dfn>nivattabīja</dfn></dt><dd><p><span class='case'>mfn.</span> (intrans.) returns, turns round, turns back; gives up; stops, ceases; tums away from.</p></dd></dl>"
+        "text": "<dl id='nivattabīja'><dt><dfn>nivattabīja</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose seed is inoperative?</p></dd></dl>"
     },
     {
         "word": "nivattati",
-        "text": "<dl id='nivattati'><dt data-main-entry='nivattati'><dfn>nivattati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivattati'><dt data-main-entry='nivattati'><dfn>nivattati</dfn></dt><dd><p><span class='case'>mfn.</span> (intrans.) returns, turns round, turns back; gives up; stops, ceases; tums away from.</p></dd></dl>"
     },
     {
         "word": "nivattanta",
-        "text": "<dl id='nivattanta'><dt data-main-entry='nivattati'><dfn>nivattanta</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n.</span> Makes to return, turn round, turn back; makes give up; makes to stop, ceases; makes to turn away from.</p></dd></dl>"
+        "text": "<dl id='nivattanta'><dt data-main-entry='nivattati'><dfn>nivattanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivattāpeti",
-        "text": "<dl id='nivattāpeti'><dt><dfn>nivattāpeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span></p><ol type='1' class='decimal'><li>makes to return, turn round, turn back; makes give up; makes to stop, ceases; makes to turn away from.</li></ol></dd></dl>"
+        "text": "<dl id='nivattāpeti'><dt><dfn>nivattāpeti</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n.</span> Makes to return, turn round, turn back; makes give up; makes to stop, ceases; makes to turn away from.</p></dd></dl>"
     },
     {
         "word": "nivattāpetvā",
-        "text": "<dl id='nivattāpetvā'><dt><dfn>nivattāpetvā</dfn></dt><dd><p><span class='case'>absol. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivattāpetvā'><dt><dfn>nivattāpetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span></p><ol type='1' class='decimal'><li>makes to return, turn round, turn back; makes give up; makes to stop, ceases; makes to turn away from.</li></ol></dd></dl>"
     },
     {
         "word": "nivattitabba",
-        "text": "<dl id='nivattitabba'><dt><dfn>nivattitabba</dfn></dt><dd><p><span class='case'>fpp (mf)n.</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivattitabba'><dt><dfn>nivattitabba</dfn></dt><dd><p><span class='case'>absol. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivatteti",
-        "text": "<dl id='nivatteti'><dt data-main-entry='nivatati'><dfn>nivatteti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivatteti'><dt data-main-entry='nivatati'><dfn>nivatteti</dfn></dt><dd><p><span class='case'>fpp (mf)n.</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivattenta",
-        "text": "<dl id='nivattenta'><dt data-main-entry='nivatati'><dfn>nivattenta</dfn></dt><dd><p><span class='case'>part. pr. mf(~entī)n.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>clothed in or with; wearing (esp. an under-garment)</li><li>worn; used.</li></ol></li><li>(m.n.) clothing; an (undergarment)</li></ol></dd></dl>"
+        "text": "<dl id='nivattenta'><dt data-main-entry='nivatati'><dfn>nivattenta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivattati</span> (see <i><a href='/define/nivattati'>nivattati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivattha",
-        "text": "<dl id='nivattha'><dt data-main-entry='nivasati'><dfn>nivattha</dfn></dt><dd><p><span class='case'>mfn. & neuter</span> throws down; scatters.</p></dd></dl>"
+        "text": "<dl id='nivattha'><dt data-main-entry='nivasati'><dfn>nivattha</dfn></dt><dd><p><span class='case'>part. pr. mf(~entī)n.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>clothed in or with; wearing (esp. an under-garment)</li><li>worn; used.</li></ol></li><li>(m.n.) clothing; an (undergarment)</li></ol></dd></dl>"
     },
     {
         "word": "nivapati",
-        "text": "<dl id='nivapati'><dt><dfn>nivapati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> clothes; dresses oneself.</p></dd></dl>"
+        "text": "<dl id='nivapati'><dt><dfn>nivapati</dfn></dt><dd><p><span class='case'>mfn. & neuter</span> throws down; scatters.</p></dd></dl>"
     },
     {
         "word": "nivasati",
-        "text": "<dl id='nivasati'><dt data-main-entry='nivasati'><dfn>nivasati</dfn><sup>1</sup></dt><dd><p><span class='case'>pr. 3 sg.</span> passes or spends time; dwells, lives (in), inhabits.</p></dd><dt><dfn>nivasati</dfn><sup>2</sup></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>(mfn.) sheltered from the wind; unruffled, calm; free from drafts; safe, secure.</li><li>(n.) a place sheltered from the wind; absence of wind, calm, stillness; safety, security.</li></ol></dd></dl>"
+        "text": "<dl id='nivasati'><dt data-main-entry='nivasati'><dfn>nivasati</dfn><sup>1</sup></dt><dd><p><span class='case'>pr. 3 sg.</span> clothes; dresses oneself.</p></dd><dt><dfn>nivasati</dfn><sup>2</sup></dt><dd><p><span class='case'>pr. 3 sg.</span> passes or spends time; dwells, lives (in), inhabits.</p></dd></dl>"
     },
     {
         "word": "nivāta",
-        "text": "<dl id='nivāta'><dt><dfn>nivāta</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn. & neuter</span> humble; modest; biddable; calm, mild.</p></dd><dt><dfn>nivāta</dfn><sup>2</sup></dt><dd><p><span class='case'>mfn.</span> seed, grain; feed, fodder; a feeding place.</p></dd></dl>"
+        "text": "<dl id='nivāta'><dt><dfn>nivāta</dfn><sup>1</sup></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>(mfn.) sheltered from the wind; unruffled, calm; free from drafts; safe, secure.</li><li>(n.) a place sheltered from the wind; absence of wind, calm, stillness; safety, security.</li></ol></p></dd><dt><dfn>nivāta</dfn><sup>2</sup></dt><dd><p><span class='case'>mfn. & neuter</span> humble; modest; biddable; calm, mild.</p></dd></dl>"
     },
     {
         "word": "nivāpa",
-        "text": "<dl id='nivāpa'><dt><dfn>nivāpa</dfn></dt><dd><p><span class='case'>masculine</span> nourished on grain.</p></dd></dl>"
+        "text": "<dl id='nivāpa'><dt><dfn>nivāpa</dfn></dt><dd><p><span class='case'>mfn.</span> seed, grain; feed, fodder; a feeding place.</p></dd></dl>"
     },
     {
         "word": "nivāpapuṭṭha",
-        "text": "<dl id='nivāpapuṭṭha'><dt><dfn>nivāpapuṭṭha</dfn></dt><dd><p><span class='case'>mfn.</span> warding off, keeping out, preventing; restraining; obstructing.</p></dd></dl>"
+        "text": "<dl id='nivāpapuṭṭha'><dt><dfn>nivāpapuṭṭha</dfn></dt><dd><p><span class='case'>masculine</span> nourished on grain.</p></dd></dl>"
     },
     {
         "word": "nivāraṇa",
-        "text": "<dl id='nivāraṇa'><dt><dfn>nivāraṇa</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāraṇa'><dt><dfn>nivāraṇa</dfn></dt><dd><p><span class='case'>mfn.</span> warding off, keeping out, preventing; restraining; obstructing.</p></dd></dl>"
     },
     {
         "word": "nivārayati",
-        "text": "<dl id='nivārayati'><dt><dfn>nivārayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivārayati'><dt><dfn>nivārayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāriyamāna",
-        "text": "<dl id='nivāriyamāna'><dt><dfn>nivāriyamāna</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn.</span> one who holds back or restrains; one who keeps out.</p></dd></dl>"
-    },
-    {
-        "word": "nivāretar",
-        "text": "<dl id='nivāretar'><dt><dfn>nivāreta(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāriyamāna'><dt><dfn>nivāriyamāna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāreta",
-        "text": "<dl id='nivāreta'><dt><dfn>nivāreta(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāretar'><dt><dfn>nivāreta(r)</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn.</span> one who holds back or restrains; one who keeps out.</p></dd></dl>"
+    },
+    {
+        "word": "nivāretar",
+        "text": "<dl id='nivāretar'><dt><dfn>nivāreta(r)</dfn></dt><dd><p><span class='case'>pass. part. pr. mfn.</span> one who holds back or restrains; one who keeps out.</p></dd></dl>"
     },
     {
         "word": "nivāretabba",
-        "text": "<dl id='nivāretabba'><dt><dfn>nivāretabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> keeps out; holds back from, restrains; obstructs; prevents; forbids.</p></dd></dl>"
+        "text": "<dl id='nivāretabba'><dt><dfn>nivāretabba</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāreti",
-        "text": "<dl id='nivāreti'><dt data-main-entry='nivarati'><dfn>nivāreti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāreti'><dt data-main-entry='nivarati'><dfn>nivāreti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> keeps out; holds back from, restrains; obstructs; prevents; forbids.</p></dd></dl>"
     },
     {
         "word": "nivāretvā",
-        "text": "<dl id='nivāretvā'><dt data-main-entry='nivarati'><dfn>nivāretvā</dfn></dt><dd><p><span class='case'>absol. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāretvā'><dt data-main-entry='nivarati'><dfn>nivāretvā</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāresi",
-        "text": "<dl id='nivāresi'><dt data-main-entry='nivarati'><dfn>nivāresi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāresi'><dt data-main-entry='nivarati'><dfn>nivāresi</dfn></dt><dd><p><span class='case'>absol. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāresuṃ",
-        "text": "<dl id='nivāresuṃ'><dt><dfn>nivāresuṃ</dfn></dt><dd><p><span class='case'>3 pl.</span></p><ol type='1' class='decimal'><li>living, dwelling; stay, residence; where one lives, a dwelling-place, a home.</li><li>where one is, a state of existence.</li></ol></dd></dl>"
+        "text": "<dl id='nivāresuṃ'><dt><dfn>nivāresuṃ</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivāreti</span> (see <i><a href='/define/nivāreti'>nivāreti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsa",
-        "text": "<dl id='nivāsa'><dt><dfn>nivāsa</dfn></dt><dd><p><span class='case'>masculine</span> dress, clothing; an undergarment; wearing (an (under) garment)</p></dd></dl>"
+        "text": "<dl id='nivāsa'><dt><dfn>nivāsa</dfn></dt><dd><p><span class='case'>3 pl.</span></p><ol type='1' class='decimal'><li>living, dwelling; stay, residence; where one lives, a dwelling-place, a home.</li><li>where one is, a state of existence.</li></ol></dd></dl>"
     },
     {
         "word": "nivāsana",
-        "text": "<dl id='nivāsana'><dt><dfn>nivāsana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsana'><dt><dfn>nivāsana</dfn></dt><dd><p><span class='case'>masculine</span> dress, clothing; an undergarment; wearing (an (under) garment)</p></dd></dl>"
     },
     {
         "word": "nivāsayati",
-        "text": "<dl id='nivāsayati'><dt><dfn>nivāsayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> living (in), dwelling, staying; a (permanent) inhabitant.</p></dd></dl>"
-    },
-    {
-        "word": "nivāsin",
-        "text": "<dl id='nivāsin'><dt><dfn>nivāsi(n)</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsayati'><dt><dfn>nivāsayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsi",
-        "text": "<dl id='nivāsi'><dt><dfn>nivāsi(n)</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsin'><dt><dfn>nivāsi(n)</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> living (in), dwelling, staying; a (permanent) inhabitant.</p></dd></dl>"
+    },
+    {
+        "word": "nivāsin",
+        "text": "<dl id='nivāsin'><dt><dfn>nivāsi(n)</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> living (in), dwelling, staying; a (permanent) inhabitant.</p></dd></dl>"
     },
     {
         "word": "nivāsetabba",
-        "text": "<dl id='nivāsetabba'><dt><dfn>nivāsetabba</dfn></dt><dd><p><span class='case'>mfn. & n. impers. of nivāsati</span> puts on (a garment), wears; dresses, clothes oneself (in an (under) garment); makes put on, clothes (see <i><a href='/define/nivāsati'>nivāsati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsetabba'><dt><dfn>nivāsetabba</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāseti",
-        "text": "<dl id='nivāseti'><dt data-main-entry='nivasati'><dfn>nivāseti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāseti'><dt data-main-entry='nivasati'><dfn>nivāseti</dfn></dt><dd><p><span class='case'>mfn. & n. impers. of nivāsati</span> puts on (a garment), wears; dresses, clothes oneself (in an (under) garment); makes put on, clothes (see <i><a href='/define/nivāsati'>nivāsati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsetvā",
-        "text": "<dl id='nivāsetvā'><dt data-main-entry='nivasati'><dfn>nivāsetvā</dfn></dt><dd><p><span class='case'>absol. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsetvā'><dt data-main-entry='nivasati'><dfn>nivāsetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsenta",
-        "text": "<dl id='nivāsenta'><dt data-main-entry='nivasati'><dfn>nivāsenta</dfn></dt><dd><p><span class='case'>part. pr. mf(~entī)n. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsenta'><dt data-main-entry='nivasati'><dfn>nivāsenta</dfn></dt><dd><p><span class='case'>absol. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsesi",
-        "text": "<dl id='nivāsesi'><dt data-main-entry='nivasati'><dfn>nivāsesi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsesi'><dt data-main-entry='nivasati'><dfn>nivāsesi</dfn></dt><dd><p><span class='case'>part. pr. mf(~entī)n. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivāsesuṃ",
-        "text": "<dl id='nivāsesuṃ'><dt><dfn>nivāsesuṃ</dfn></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/nibbiṭṭha'>nibbiṭṭha</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivāsesuṃ'><dt><dfn>nivāsesuṃ</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivāseti</span> (see <i><a href='/define/nivāseti'>nivāseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niviṭṭha",
-        "text": "<dl id='niviṭṭha'><dt data-main-entry='nivisati'><dfn>niviṭṭha</dfn><sup>1</sup></dt><dd><p><span class='case'>pp mfn. of nivisati</span></p><ol type='1' class='decimal'><li>settled; encamped.</li><li>resting or staying in; turned to, intent upon (see <i><a href='/define/nivisati'>nivisati</a></i>)</li></ol></dd><dt><dfn>niviṭṭha</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn.</span> enters or penetrates into; settles (on); is intent on; is convinced, insists on; is founded.</p></dd></dl>"
+        "text": "<dl id='niviṭṭha'><dt data-main-entry='nivisati'><dfn>niviṭṭha</dfn><sup>1</sup></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/nibbiṭṭha'>nibbiṭṭha</a></i>)</p></dd><dt><dfn>niviṭṭha</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn. of nivisati</span></p><ol type='1' class='decimal'><li>settled; encamped.</li><li>resting or staying in; turned to, intent upon (see <i><a href='/define/nivisati'>nivisati</a></i>)</li></ol></dd></dl>"
     },
     {
         "word": "nivisati",
-        "text": "<dl id='nivisati'><dt data-main-entry='nivisati'><dfn>nivisati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> settles down; enters; establishes oneself.</p></dd></dl>"
+        "text": "<dl id='nivisati'><dt data-main-entry='nivisati'><dfn>nivisati</dfn></dt><dd><p><span class='case'>pp mfn.</span> enters or penetrates into; settles (on); is intent on; is convinced, insists on; is founded.</p></dd></dl>"
     },
     {
         "word": "nivisamāna",
-        "text": "<dl id='nivisamāna'><dt><dfn>nivisamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nivisati</span> (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivisamāna'><dt><dfn>nivisamāna</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> settles down; enters; establishes oneself.</p></dd></dl>"
     },
     {
         "word": "nivisi",
-        "text": "<dl id='nivisi'><dt data-main-entry='nivisati'><dfn>nivisi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivisati</span> (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivisi'><dt data-main-entry='nivisati'><dfn>nivisi</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nivisati</span> (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivissa",
-        "text": "<dl id='nivissa'><dt><dfn>nivissa</dfn></dt><dd><p><span class='case'>absol. of nivisati</span> speaking insistently, dogmatically (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivissa'><dt><dfn>nivissa</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nivisati</span> (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivissavāda",
-        "text": "<dl id='nivissavāda'><dt><dfn>nivissavāda</dfn></dt><dd><p><span class='case'>mfn.</span> speaking insistently, dogmatically (see <i><a href='/define/nivissa'>nivissa</a></i>)</p></dd></dl>"
-    },
-    {
-        "word": "nivissavādin",
-        "text": "<dl id='nivissavādin'><dt><dfn>nivissavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nivissavāda'>nivissavāda</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivissavāda'><dt><dfn>nivissavāda</dfn></dt><dd><p><span class='case'>absol. of nivisati</span> speaking insistently, dogmatically (see <i><a href='/define/nivisati'>nivisati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivissavādi",
-        "text": "<dl id='nivissavādi'><dt><dfn>nivissavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nivissavāda'>nivissavāda</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivissavādin'><dt><dfn>nivissavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> speaking insistently, dogmatically (see <i><a href='/define/nivissa'>nivissa</a></i>)</p></dd></dl>"
+    },
+    {
+        "word": "nivissavādin",
+        "text": "<dl id='nivissavādin'><dt><dfn>nivissavādi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> speaking insistently, dogmatically (see <i><a href='/define/nivissa'>nivissa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivuṭa",
-        "text": "<dl id='nivuṭa'><dt><dfn>nivuṭa</dfn></dt><dd><p><span class='case'>mfn.</span> hindered, obstructed; suppressed; surrounded, enveloped.</p></dd></dl>"
+        "text": "<dl id='nivuṭa'><dt><dfn>nivuṭa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nivissavāda'>nivissavāda</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivuta",
-        "text": "<dl id='nivuta'><dt data-main-entry='nivarati'><dfn>nivuta</dfn></dt><dd><p><span class='case'>mfn.</span> who is kept from the brahma world.</p></dd></dl>"
+        "text": "<dl id='nivuta'><dt data-main-entry='nivarati'><dfn>nivuta</dfn></dt><dd><p><span class='case'>mfn.</span> hindered, obstructed; suppressed; surrounded, enveloped.</p></dd></dl>"
     },
     {
         "word": "nivutabrahmaloka",
-        "text": "<dl id='nivutabrahmaloka'><dt><dfn>nivutabrahmaloka</dfn></dt><dd><p><span class='case'>mfn.</span> shaved, cut off.</p></dd></dl>"
+        "text": "<dl id='nivutabrahmaloka'><dt><dfn>nivutabrahmaloka</dfn></dt><dd><p><span class='case'>mfn.</span> who is kept from the brahma world.</p></dd></dl>"
     },
     {
         "word": "nivutta",
-        "text": "<dl id='nivutta'><dt><dfn>nivutta</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn.</span> thrown down; scattered (see <i><a href='/define/nivapati'>nivapati</a></i>)</p></dd><dt><dfn>nivutta</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn. of nivutta</span> whose hair has been shaved off (see <i><a href='/define/nivutta'>nivutta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivutta'><dt><dfn>nivutta</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn.</span> shaved, cut off.</p></dd><dt><dfn>nivutta</dfn><sup>2</sup></dt><dd><p><span class='case'>mfn.</span> thrown down; scattered (see <i><a href='/define/nivapati'>nivapati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivuttakesa",
-        "text": "<dl id='nivuttakesa'><dt><dfn>nivuttakesa</dfn></dt><dd><p><span class='case'>mfn.</span> having lived, stayed (see <i><a href='/define/nivasati'>nivasati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivuttakesa'><dt><dfn>nivuttakesa</dfn></dt><dd><p><span class='case'>pp mfn. of nivutta</span> whose hair has been shaved off (see <i><a href='/define/nivutta'>nivutta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivusita",
-        "text": "<dl id='nivusita'><dt><dfn>nivusita</dfn></dt><dd><p><span class='case'>pp mfn.</span> settling (on or in); a settlement; a house, a home.</p></dd></dl>"
+        "text": "<dl id='nivusita'><dt><dfn>nivusita</dfn></dt><dd><p><span class='case'>mfn.</span> having lived, stayed (see <i><a href='/define/nivasati'>nivasati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivesa",
-        "text": "<dl id='nivesa'><dt><dfn>nivesa</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>settlement; a dwelling-place, a house, a home.</li><li>settling (on or in), attachment (to); where one settles.</li></ol></dd></dl>"
+        "text": "<dl id='nivesa'><dt><dfn>nivesa</dfn></dt><dd><p><span class='case'>pp mfn.</span> settling (on or in); a settlement; a house, a home.</p></dd></dl>"
     },
     {
         "word": "nivesana",
-        "text": "<dl id='nivesana'><dt><dfn>nivesana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesana'><dt><dfn>nivesana</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>settlement; a dwelling-place, a house, a home.</li><li>settling (on or in), attachment (to); where one settles.</li></ol></dd></dl>"
     },
     {
         "word": "nivesayati",
-        "text": "<dl id='nivesayati'><dt><dfn>nivesayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesayati'><dt><dfn>nivesayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivesayi",
-        "text": "<dl id='nivesayi'><dt><dfn>nivesayi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesayi'><dt><dfn>nivesayi</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivesiya",
-        "text": "<dl id='nivesiya'><dt><dfn>nivesiya</dfn></dt><dd><p><span class='case'>absol. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesiya'><dt><dfn>nivesiya</dfn></dt><dd><p><span class='case'>aor. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivesetabba",
-        "text": "<dl id='nivesetabba'><dt><dfn>nivesetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> makes enter; directs towards; causes to settle (on); establishes, founds; gives in marriage (see <i><a href='/define/nivasati'>nivasati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesetabba'><dt><dfn>nivesetabba</dfn></dt><dd><p><span class='case'>absol. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "niveseti",
-        "text": "<dl id='niveseti'><dt data-main-entry='nivisati'><dfn>niveseti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
+        "text": "<dl id='niveseti'><dt data-main-entry='nivisati'><dfn>niveseti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> makes enter; directs towards; causes to settle (on); establishes, founds; gives in marriage (see <i><a href='/define/nivasati'>nivasati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nivesesi",
-        "text": "<dl id='nivesesi'><dt data-main-entry='nivesati'><dfn>nivesesi</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nisaṅkhiti'>nisaṅkhiti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nivesesi'><dt data-main-entry='nivesati'><dfn>nivesesi</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of niveseti</span> (see <i><a href='/define/niveseti'>niveseti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisaṅkhati",
-        "text": "<dl id='nisaṅkhati'><dt><dfn>nisaṅkhati</dfn></dt><dd><p><span class='case'>feminine</span> formation; accumulation.</p></dd></dl>"
+        "text": "<dl id='nisaṅkhati'><dt><dfn>nisaṅkhati</dfn></dt><dd><p><span class='case'>aor. 3 sg.</span> (see <i><a href='/define/nisaṅkhiti'>nisaṅkhiti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisaṅkhiti",
-        "text": "<dl id='nisaṅkhiti'><dt><dfn>nisaṅkhiti</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisaṅkhiti'><dt><dfn>nisaṅkhiti</dfn></dt><dd><p><span class='case'>feminine</span> formation; accumulation.</p></dd></dl>"
     },
     {
         "word": "nisajja",
-        "text": "<dl id='nisajja'><dt data-main-entry='nisīdati'><dfn>nisajja</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisajja'><dt data-main-entry='nisīdati'><dfn>nisajja</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisajjati",
-        "text": "<dl id='nisajjati'><dt><dfn>nisajjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (the act of) sitting, sitting down; a session.</p></dd></dl>"
+        "text": "<dl id='nisajjati'><dt><dfn>nisajjati</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisajjā",
-        "text": "<dl id='nisajjā'><dt><dfn>nisajjā</dfn></dt><dd><p><span class='case'>feminine</span> a stone for grinding, a (lower) millstone.</p></dd></dl>"
+        "text": "<dl id='nisajjā'><dt><dfn>nisajjā</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (the act of) sitting, sitting down; a session.</p></dd></dl>"
     },
     {
         "word": "nisadā",
-        "text": "<dl id='nisadā'><dt><dfn>nisadā</dfn></dt><dd><p><span class='case'>f., ~a, neuter</span> a stone for grinding; an (upper, smaller) millstone or stone roller.</p></dd></dl>"
+        "text": "<dl id='nisadā'><dt><dfn>nisadā</dfn></dt><dd><p><span class='case'>feminine</span> a stone for grinding, a (lower) millstone.</p></dd></dl>"
     },
     {
         "word": "nisadāpota",
-        "text": "<dl id='nisadāpota'><dt><dfn>nisadāpota</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nisadāpotaka'>nisadāpotaka</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisadāpota'><dt><dfn>nisadāpota</dfn></dt><dd><p><span class='case'>f., ~a, neuter</span> a stone for grinding; an (upper, smaller) millstone or stone roller.</p></dd></dl>"
     },
     {
         "word": "nisadāpotaka",
-        "text": "<dl id='nisadāpotaka'><dt><dfn>nisadāpotaka</dfn></dt><dd><p><span class='case'>masculine</span> (close) observation; careful attention.</p></dd></dl>"
+        "text": "<dl id='nisadāpotaka'><dt><dfn>nisadāpotaka</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nisadāpotaka'>nisadāpotaka</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisanti",
-        "text": "<dl id='nisanti'><dt><dfn>nisanti</dfn></dt><dd><p><span class='case'>feminine</span> a bull; a leader; the best or most excellent (of a group)</p></dd></dl>"
+        "text": "<dl id='nisanti'><dt><dfn>nisanti</dfn></dt><dd><p><span class='case'>masculine</span> (close) observation; careful attention.</p></dd></dl>"
     },
     {
         "word": "nisabha",
-        "text": "<dl id='nisabha'><dt><dfn>nisabha</dfn></dt><dd><p><span class='case'>masculine</span> the being (like) a bull?</p></dd></dl>"
+        "text": "<dl id='nisabha'><dt><dfn>nisabha</dfn></dt><dd><p><span class='case'>feminine</span> a bull; a leader; the best or most excellent (of a group)</p></dd></dl>"
     },
     {
         "word": "nisabhavatā",
-        "text": "<dl id='nisabhavatā'><dt><dfn>nisabhavatā</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisabhavatā'><dt><dfn>nisabhavatā</dfn></dt><dd><p><span class='case'>masculine</span> the being (like) a bull?</p></dd></dl>"
     },
     {
         "word": "nisamma",
-        "text": "<dl id='nisamma'><dt><dfn>nisamma</dfn></dt><dd><p><span class='case'>absol. of nisamma</span> acting after careful consideration (see <i><a href='/define/nisamma'>nisamma</a></i>)</p></dd></dl>"
-    },
-    {
-        "word": "nisammakārin",
-        "text": "<dl id='nisammakārin'><dt><dfn>nisammakāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> closely observing; attending carefully to.</p></dd></dl>"
+        "text": "<dl id='nisamma'><dt><dfn>nisamma</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisammakāri",
-        "text": "<dl id='nisammakāri'><dt><dfn>nisammakāri(n)</dfn></dt><dd><p><span class='case'>mfn.</span> closely observing; attending carefully to.</p></dd></dl>"
+        "text": "<dl id='nisammakārin'><dt><dfn>nisammakāri(n)</dfn></dt><dd><p><span class='case'>absol. of nisamma</span> acting after careful consideration (see <i><a href='/define/nisamma'>nisamma</a></i>)</p></dd></dl>"
+    },
+    {
+        "word": "nisammakārin",
+        "text": "<dl id='nisammakārin'><dt><dfn>nisammakāri(n)</dfn></dt><dd><p><span class='case'>absol. of nisamma</span> acting after careful consideration (see <i><a href='/define/nisamma'>nisamma</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisāmaka",
-        "text": "<dl id='nisāmaka'><dt><dfn>nisāmaka</dfn></dt><dd><p><span class='case'>mfn.</span> naturally disposed to attending carefully; given to closely observing.</p></dd></dl>"
+        "text": "<dl id='nisāmaka'><dt><dfn>nisāmaka</dfn></dt><dd><p><span class='case'>mfn.</span> closely observing; attending carefully to.</p></dd></dl>"
     },
     {
         "word": "nisāmakajātika",
-        "text": "<dl id='nisāmakajātika'><dt><dfn>nisāmakajātika</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nisāmakajātiya'>nisāmakajātiya</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisāmakajātika'><dt><dfn>nisāmakajātika</dfn></dt><dd><p><span class='case'>mfn.</span> naturally disposed to attending carefully; given to closely observing.</p></dd></dl>"
     },
     {
         "word": "nisāmakajātiya",
-        "text": "<dl id='nisāmakajātiya'><dt><dfn>nisāmakajātiya</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisāmakajātiya'><dt><dfn>nisāmakajātiya</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nisāmakajātiya'>nisāmakajātiya</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisāmayati",
-        "text": "<dl id='nisāmayati'><dt><dfn>nisāmayati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisāmeti</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisāmayati'><dt><dfn>nisāmayati</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisāmayi",
-        "text": "<dl id='nisāmayi'><dt><dfn>nisāmayi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nisāmeti</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisāmayi'><dt><dfn>nisāmayi</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisāmeti</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisāmayitvā",
-        "text": "<dl id='nisāmayitvā'><dt><dfn>nisāmayitvā</dfn></dt><dd><p><span class='case'>absol.</span> hears; observes (closely); attends carefully (to)</p></dd></dl>"
+        "text": "<dl id='nisāmayitvā'><dt><dfn>nisāmayitvā</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nisāmeti</span> (see <i><a href='/define/nisāmeti'>nisāmeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisāmeti",
-        "text": "<dl id='nisāmeti'><dt data-main-entry='nisāmeti'><dfn>nisāmeti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisīdati</span> sitting down; (being) seated (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisāmeti'><dt data-main-entry='nisāmeti'><dfn>nisāmeti</dfn></dt><dd><p><span class='case'>absol.</span> hears; observes (closely); attends carefully (to)</p></dd></dl>"
     },
     {
         "word": "nisinna",
-        "text": "<dl id='nisinna'><dt data-main-entry='nisīdati'><dfn>nisinna</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>(mfn.) sitting; seated.</li><li>(n.) the act of sitting.</li></ol></dd></dl>"
+        "text": "<dl id='nisinna'><dt data-main-entry='nisīdati'><dfn>nisinna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisīdati</span> sitting down; (being) seated (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisinnaka",
-        "text": "<dl id='nisinnaka'><dt><dfn>nisinnaka</dfn></dt><dd><p><span class='case'>mfn. & n. of nisinna</span> the place where (someone) sits or is sitting or has sat (see <i><a href='/define/nisinna'>nisinna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisinnaka'><dt><dfn>nisinnaka</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>(mfn.) sitting; seated.</li><li>(n.) the act of sitting.</li></ol></dd></dl>"
     },
     {
         "word": "nissinnokasa",
-        "text": "<dl id='nissinnokasa'><dt><dfn>nissinnokasa</dfn></dt><dd><p><span class='case'>masculine</span> midnight, night.</p></dd></dl>"
+        "text": "<dl id='nissinnokasa'><dt><dfn>nissinnokasa</dfn></dt><dd><p><span class='case'>mfn. & n. of nisinna</span> the place where (someone) sits or is sitting or has sat (see <i><a href='/define/nisinna'>nisinna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisītha",
-        "text": "<dl id='nisītha'><dt><dfn>nisītha</dfn></dt><dd><p><span class='case'>masculine</span> sits down; is seated, sits; sits up.</p></dd></dl>"
+        "text": "<dl id='nisītha'><dt><dfn>nisītha</dfn></dt><dd><p><span class='case'>masculine</span> midnight, night.</p></dd></dl>"
     },
     {
         "word": "nisīdati",
-        "text": "<dl id='nisīdati'><dt data-main-entry='nisīdati'><dfn>nisīdati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> something to sit on; a rug or mat for sitting on.</p></dd></dl>"
+        "text": "<dl id='nisīdati'><dt data-main-entry='nisīdati'><dfn>nisīdati</dfn></dt><dd><p><span class='case'>masculine</span> sits down; is seated, sits; sits up.</p></dd></dl>"
     },
     {
         "word": "nisīdana",
-        "text": "<dl id='nisīdana'><dt><dfn>nisīdana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdana'><dt><dfn>nisīdana</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> something to sit on; a rug or mat for sitting on.</p></dd></dl>"
     },
     {
         "word": "nisīdanta",
-        "text": "<dl id='nisīdanta'><dt data-main-entry='nisīdati'><dfn>nisīdanta</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdanta'><dt data-main-entry='nisīdati'><dfn>nisīdanta</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdāpita",
-        "text": "<dl id='nisīdāpita'><dt data-main-entry='nisīdati'><dfn>nisīdāpita</dfn></dt><dd><p><span class='case'>pp mfn. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdāpita'><dt data-main-entry='nisīdati'><dfn>nisīdāpita</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdāpiyati",
-        "text": "<dl id='nisīdāpiyati'><dt><dfn>nisīdāpiyati</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nisīdati</span> causes to sit down, seats; invites to sit; makes sit up; lets stay; places; makes kneel; forces down (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdāpiyati'><dt><dfn>nisīdāpiyati</dfn></dt><dd><p><span class='case'>pp mfn. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdāpeti",
-        "text": "<dl id='nisīdāpeti'><dt data-main-entry='nisīdati'><dfn>nisīdāpeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdāpeti'><dt data-main-entry='nisīdati'><dfn>nisīdāpeti</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nisīdati</span> causes to sit down, seats; invites to sit; makes sit up; lets stay; places; makes kneel; forces down (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdāpetvā",
-        "text": "<dl id='nisīdāpetvā'><dt data-main-entry='nisīdati'><dfn>nisīdāpetvā</dfn></dt><dd><p><span class='case'>ca.ger of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdāpetvā'><dt data-main-entry='nisīdati'><dfn>nisīdāpetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisīdapeti</span> (see <i><a href='/define/nisīdapeti'>nisīdapeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdi",
-        "text": "<dl id='nisīdi'><dt><dfn>nisīdi</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdi'><dt><dfn>nisīdi</dfn></dt><dd><p><span class='case'>ca.ger of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdiṃsu",
-        "text": "<dl id='nisīdiṃsu'><dt><dfn>nisīdiṃsu</dfn></dt><dd><p><span class='case'>3 pl.</span> (from nisīdati) one who sits.</p></dd></dl>"
-    },
-    {
-        "word": "nisīditar",
-        "text": "<dl id='nisīditar'><dt><dfn>nisīdita(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīdiṃsu'><dt><dfn>nisīdiṃsu</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīdita",
-        "text": "<dl id='nisīdita'><dt><dfn>nisīdita(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīditar'><dt><dfn>nisīdita(r)</dfn></dt><dd><p><span class='case'>3 pl.</span> (from nisīdati) one who sits.</p></dd></dl>"
+    },
+    {
+        "word": "nisīditar",
+        "text": "<dl id='nisīditar'><dt><dfn>nisīdita(r)</dfn></dt><dd><p><span class='case'>3 pl.</span> (from nisīdati) one who sits.</p></dd></dl>"
     },
     {
         "word": "nisīditabba",
-        "text": "<dl id='nisīditabba'><dt data-main-entry='nisīdati'><dfn>nisīditabba</dfn></dt><dd><p><span class='case'>fpp n. impers. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīditabba'><dt data-main-entry='nisīdati'><dfn>nisīditabba</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīditvā",
-        "text": "<dl id='nisīditvā'><dt data-main-entry='nisīdati'><dfn>nisīditvā</dfn></dt><dd><p><span class='case'>absol. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisīditvā'><dt data-main-entry='nisīdati'><dfn>nisīditvā</dfn></dt><dd><p><span class='case'>fpp n. impers. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisīditvāna",
-        "text": "<dl id='nisīditvāna'><dt><dfn>nisīditvāna</dfn></dt><dd><p><span class='case'>absol.</span> knocks down; treads down.</p></dd></dl>"
+        "text": "<dl id='nisīditvāna'><dt><dfn>nisīditvāna</dfn></dt><dd><p><span class='case'>absol. of nisīdati</span> (see <i><a href='/define/nisīdati'>nisīdati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisumbhati",
-        "text": "<dl id='nisumbhati'><dt><dfn>nisumbhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> restraint; prevention, prohibition; contradiction, denial.</p></dd></dl>"
+        "text": "<dl id='nisumbhati'><dt><dfn>nisumbhati</dfn></dt><dd><p><span class='case'>absol.</span> knocks down; treads down.</p></dd></dl>"
     },
     {
         "word": "nisedha",
-        "text": "<dl id='nisedha'><dt><dfn>nisedha</dfn></dt><dd><p><span class='case'>masculine</span> prevents; prohibits; suppresses.</p></dd></dl>"
+        "text": "<dl id='nisedha'><dt><dfn>nisedha</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> restraint; prevention, prohibition; contradiction, denial.</p></dd></dl>"
     },
     {
         "word": "nisedhati",
-        "text": "<dl id='nisedhati'><dt><dfn>nisedhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisedhati'><dt><dfn>nisedhati</dfn></dt><dd><p><span class='case'>masculine</span> prevents; prohibits; suppresses.</p></dd></dl>"
     },
     {
         "word": "nisedhayati",
-        "text": "<dl id='nisedhayati'><dt><dfn>nisedhayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisedheti</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisedhayati'><dt><dfn>nisedhayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisedhetabba",
-        "text": "<dl id='nisedhetabba'><dt data-main-entry='nisedheti'><dfn>nisedhetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> prevents; prohibits; keeps off (see <i><a href='/define/nisedhati'>nisedhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisedhetabba'><dt data-main-entry='nisedheti'><dfn>nisedhetabba</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisedheti</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisedheti",
-        "text": "<dl id='nisedheti'><dt data-main-entry='nisedheti'><dfn>nisedheti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisedheti</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisedheti'><dt data-main-entry='nisedheti'><dfn>nisedheti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> prevents; prohibits; keeps off (see <i><a href='/define/nisedhati'>nisedhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisedhesuṃ",
-        "text": "<dl id='nisedhesuṃ'><dt><dfn>nisedhesuṃ</dfn></dt><dd><p><span class='case'>3 pl.</span> frequents, inhabits, resorts to; serves, waits upon; practices, performs; indulges in.</p></dd></dl>"
+        "text": "<dl id='nisedhesuṃ'><dt><dfn>nisedhesuṃ</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nisedheti</span> (see <i><a href='/define/nisedheti'>nisedheti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisevati",
-        "text": "<dl id='nisevati'><dt data-main-entry='nisevati'><dfn>nisevati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisevati</span></p><ol type='1' class='decimal'><li>(mfn,) visited, frequented; practiced, studied; waited upon.</li><li>(n.)<ol type='i' class='lower-roman'><li>resorting to; practice.</li><li>(a sign of) frequenting; a trace? (see <i><a href='/define/nisevati'>nisevati</a></i>)</li></ol></li></ol></dd></dl>"
+        "text": "<dl id='nisevati'><dt data-main-entry='nisevati'><dfn>nisevati</dfn></dt><dd><p><span class='case'>3 pl.</span> frequents, inhabits, resorts to; serves, waits upon; practices, performs; indulges in.</p></dd></dl>"
     },
     {
         "word": "nisevita",
-        "text": "<dl id='nisevita'><dt data-main-entry='nisevati'><dfn>nisevita</dfn></dt><dd><p><span class='case'>pp mfn. & neuter</span></p><ol type='1' class='decimal'><li>subject to forfeiture; required to be surrendered; (an offense) involving surrendering, involving forfeiture.</li><li>something (to be) discharged or thrown.</li></ol></dd></dl>"
+        "text": "<dl id='nisevita'><dt data-main-entry='nisevati'><dfn>nisevita</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nisevati</span></p><ol type='1' class='decimal'><li>(mfn,) visited, frequented; practiced, studied; waited upon.</li><li>(n.)<ol type='i' class='lower-roman'><li>resorting to; practice.</li><li>(a sign of) frequenting; a trace? (see <i><a href='/define/nisevati'>nisevati</a></i>)</li></ol></li></ol></dd></dl>"
     },
     {
         "word": "nissaggiya",
-        "text": "<dl id='nissaggiya'><dt><dfn>nissaggiya</dfn></dt><dd><p><span class='case'>mfn. & n.</span> (see <i><a href='/define/nissajjiṃ'>nissajjiṃ</a></i>)</p></dd></dl>"
-    },
-    {
-        "word": "nissajjiṃ",
-        "text": "<dl id='nissajjiṃ'><dt><dfn>nissajjiṃ</dfn></dt><dd><p><span class='case'>1 sg.</span> (see <i><a href='/define/nissajjita'>nissajjita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissaggiya'><dt><dfn>nissaggiya</dfn></dt><dd><p><span class='case'>pp mfn. & neuter</span></p><ol type='1' class='decimal'><li>subject to forfeiture; required to be surrendered; (an offense) involving surrendering, involving forfeiture.</li><li>something (to be) discharged or thrown.</li></ol></dd></dl>"
     },
     {
         "word": "nissajita",
-        "text": "<dl id='nissajita'><dt><dfn>nissajita</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nissajjitvā'>nissajjitvā</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajita'><dt><dfn>nissajita</dfn></dt><dd><p><span class='case'>mfn. & n.</span> (see <i><a href='/define/nissajjiṃ'>nissajjiṃ</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajitvā",
-        "text": "<dl id='nissajitvā'><dt><dfn>nissajitvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nissajjitvāna'>nissajjitvāna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajitvā'><dt><dfn>nissajitvā</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nissajjitvā'>nissajjitvā</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajitvāna",
-        "text": "<dl id='nissajitvāna'><dt><dfn>nissajitvāna</dfn></dt><dd><p><span class='case'>absol. of nissajjati</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajitvāna'><dt><dfn>nissajitvāna</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nissajjitvāna'>nissajjitvāna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nisssajja",
-        "text": "<dl id='nisssajja'><dt><dfn>nisssajja</dfn></dt><dd><p><span class='case'>absol.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
+        "text": "<dl id='nisssajja'><dt><dfn>nisssajja</dfn></dt><dd><p><span class='case'>absol. of nissajjati</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajjati",
-        "text": "<dl id='nissajjati'><dt><dfn>nissajjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
+        "text": "<dl id='nissajjati'><dt><dfn>nissajjati</dfn></dt><dd><p><span class='case'>absol.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
+    },
+    {
+        "word": "nissajiṃ",
+        "text": "<dl id='nissajjati'><dt><dfn>nissajjati</dfn></dt><dd><p><span class='case'>absol.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
+    },
+    {
+        "word": "nissajjiṃ",
+        "text": "<dl id='nissajjati'><dt><dfn>nissajjati</dfn></dt><dd><p><span class='case'>absol.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
     },
     {
         "word": "nissajjita",
-        "text": "<dl id='nissajjita'><dt><dfn>nissajjita</dfn></dt><dd><p><span class='case'>pp mfn. of nissajjitvā</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajjita'><dt><dfn>nissajjita</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> lets go; gives up; hands over; surrenders; lets fly, throws.</p></dd></dl>"
     },
     {
         "word": "nissajjitabba",
-        "text": "<dl id='nissajjitabba'><dt><dfn>nissajjitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajjitabba'><dt><dfn>nissajjitabba</dfn></dt><dd><p><span class='case'>pp mfn. of nissajjitvā</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajjitvā",
-        "text": "<dl id='nissajjitvā'><dt data-main-entry='nissajati'><dfn>nissajjitvā</dfn></dt><dd><p><span class='case'>absol. of nissajjati</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajjitvā'><dt data-main-entry='nissajati'><dfn>nissajjitvā</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajjitvāna",
-        "text": "<dl id='nissajjitvāna'><dt><dfn>nissajjitvāna</dfn></dt><dd><p><span class='case'>absol.</span> to be given up, renounced?</p></dd></dl>"
+        "text": "<dl id='nissajjitvāna'><dt><dfn>nissajjitvāna</dfn></dt><dd><p><span class='case'>absol. of nissajjati</span> (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissajjeta",
-        "text": "<dl id='nissajjeta'><dt><dfn>nissajjeta</dfn></dt><dd><p><span class='case'>mfn.</span> (who has) gone out, left; separated (from); rid of, free from (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissajjeta'><dt><dfn>nissajjeta</dfn></dt><dd><p><span class='case'>absol.</span> to be given up, renounced?</p></dd></dl>"
     },
     {
         "word": "nissaṭa",
-        "text": "<dl id='nissaṭa'><dt data-main-entry='nissarati'><dfn>nissaṭa</dfn></dt><dd><p><span class='case'>pp mfn. of nissajjati</span> let go; set free; given up; handed over, surrendered; let fly, Thrown (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissaṭa'><dt data-main-entry='nissarati'><dfn>nissaṭa</dfn></dt><dd><p><span class='case'>mfn.</span> (who has) gone out, left; separated (from); rid of, free from (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissaṭṭha",
-        "text": "<dl id='nissaṭṭha'><dt data-main-entry='nissajati'><dfn>nissaṭṭha</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>result; outcome.</li><li>discharge; trickling down.</li></ol></dd></dl>"
+        "text": "<dl id='nissaṭṭha'><dt data-main-entry='nissajati'><dfn>nissaṭṭha</dfn></dt><dd><p><span class='case'>pp mfn. of nissajjati</span> let go; set free; given up; handed over, surrendered; let fly, Thrown (see <i><a href='/define/nissajjati'>nissajjati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissanda",
-        "text": "<dl id='nissanda'><dt><dfn>nissanda</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>support, what one depends or relies on; refuge, shelter; dependence; reliance.</li><li>support, resource; requisite.</li><li>(a relation of) dependence and guidance and supervision (under an upajjhāya or ācariya)</li></ol></dd></dl>"
+        "text": "<dl id='nissanda'><dt><dfn>nissanda</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>result; outcome.</li><li>discharge; trickling down.</li></ol></dd></dl>"
     },
     {
         "word": "nissaya",
-        "text": "<dl id='nissaya'><dt><dfn>nissaya</dfn></dt><dd><p><span class='case'>masculine & neuter</span> requiring (formally acquired) supervision, requiring a mentor.</p></dd></dl>"
+        "text": "<dl id='nissaya'><dt><dfn>nissaya</dfn></dt><dd><p><span class='case'>masculine</span></p><ol type='1' class='decimal'><li>support, what one depends or relies on; refuge, shelter; dependence; reliance.</li><li>support, resource; requisite.</li><li>(a relation of) dependence and guidance and supervision (under an upajjhāya or ācariya)</li></ol></dd></dl>"
     },
     {
         "word": "nissayakaraṇīya",
-        "text": "<dl id='nissayakaraṇīya'><dt><dfn>nissayakaraṇīya</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nissayati'>nissayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissayakaraṇīya'><dt><dfn>nissayakaraṇīya</dfn></dt><dd><p><span class='case'>masculine & neuter</span> requiring (formally acquired) supervision, requiring a mentor.</p></dd></dl>"
     },
     {
         "word": "nissayat",
-        "text": "<dl id='nissayat'><dt><dfn>nissaya(t)</dfn></dt><dd><p><span class='case'>pp mfn.</span> leans on; relies on, depends on; resorts to.</p></dd></dl>"
+        "text": "<dl id='nissayat'><dt><dfn>nissaya(t)</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nissayati'>nissayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissayati",
-        "text": "<dl id='nissayati'><dt data-main-entry='nissayati'><dfn>nissayati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (from nissayati) depending on, relying on; dependence.</p></dd></dl>"
+        "text": "<dl id='nissayati'><dt data-main-entry='nissayati'><dfn>nissayati</dfn></dt><dd><p><span class='case'>pp mfn.</span> leans on; relies on, depends on; resorts to.</p></dd></dl>"
     },
     {
         "word": "nissayana",
-        "text": "<dl id='nissayana'><dt><dfn>nissayana</dfn></dt><dd><p><span class='case'>n., ~ā, feminine</span> having a support; having supporters or mentors.</p></dd></dl>"
+        "text": "<dl id='nissayana'><dt><dfn>nissayana</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (from nissayati) depending on, relying on; dependence.</p></dd></dl>"
     },
     {
         "word": "nissayasampanna",
-        "text": "<dl id='nissayasampanna'><dt><dfn>nissayasampanna</dfn></dt><dd><p><span class='case'>mfn.</span> going out, departure; escape; separation (from), riddance; means, remedy to get rid of or counteract something.</p></dd></dl>"
+        "text": "<dl id='nissayasampanna'><dt><dfn>nissayasampanna</dfn></dt><dd><p><span class='case'>n., ~ā, feminine</span> having a support; having supporters or mentors.</p></dd></dl>"
     },
     {
         "word": "nissaraṇa",
-        "text": "<dl id='nissaraṇa'><dt><dfn>nissaraṇa</dfn></dt><dd><p><span class='case'>neuter</span> connected with, conducive to, separation, getting rid of, escape.</p></dd></dl>"
+        "text": "<dl id='nissaraṇa'><dt><dfn>nissaraṇa</dfn></dt><dd><p><span class='case'>mfn.</span> going out, departure; escape; separation (from), riddance; means, remedy to get rid of or counteract something.</p></dd></dl>"
     },
     {
         "word": "nissaraṇīya",
-        "text": "<dl id='nissaraṇīya'><dt><dfn>nissaraṇīya</dfn></dt><dd><p><span class='case'>mfn.</span> goes out, departs; escapes from; is rid of, is separated from.</p></dd></dl>"
+        "text": "<dl id='nissaraṇīya'><dt><dfn>nissaraṇīya</dfn></dt><dd><p><span class='case'>neuter</span> connected with, conducive to, separation, getting rid of, escape.</p></dd></dl>"
     },
     {
         "word": "nissarati",
-        "text": "<dl id='nissarati'><dt data-main-entry='nissarati'><dfn>nissarati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>depending on, relying on; using as one’s support.</li><li>because of; for the sake of.</li></ol></li><li>in (formal) dependence, with support; having as mentor (+ gen. or acc.)</li><li>leaning against; beside; near.</li></ol></dd></dl>"
+        "text": "<dl id='nissarati'><dt data-main-entry='nissarati'><dfn>nissarati</dfn></dt><dd><p><span class='case'>mfn.</span> goes out, departs; escapes from; is rid of, is separated from.</p></dd></dl>"
     },
     {
         "word": "nissāya",
-        "text": "<dl id='nissāya'><dt><dfn>nissāya</dfn></dt><dd><p><span class='case'>indeclinable</span> (temporary) expulsion; suspension.</p></dd></dl>"
+        "text": "<dl id='nissāya'><dt><dfn>nissāya</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li><ol type='i' class='lower-roman'><li>depending on, relying on; using as one’s support.</li><li>because of; for the sake of.</li></ol></li><li>in (formal) dependence, with support; having as mentor (+ gen. or acc.)</li><li>leaning against; beside; near.</li></ol></dd></dl>"
     },
     {
         "word": "nissāraṇa",
-        "text": "<dl id='nissāraṇa'><dt><dfn>nissāraṇa</dfn></dt><dd><p><span class='case'>f., ~a, neuter</span></p><ol type='1' class='decimal'><li>(from nissāraṇa)</li><li>involving suspension; (the formal act) connected with suspension.</li><li>to be got rid of?</li></ol></dd></dl>"
+        "text": "<dl id='nissāraṇa'><dt><dfn>nissāraṇa</dfn></dt><dd><p><span class='case'>indeclinable</span> (temporary) expulsion; suspension.</p></dd></dl>"
     },
     {
         "word": "nissāraṇīya",
-        "text": "<dl id='nissāraṇīya'><dt><dfn>nissāraṇīya</dfn></dt><dd><p><span class='case'>mfn. & n. of nissarati</span> expelled; suspended (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissāraṇīya'><dt><dfn>nissāraṇīya</dfn></dt><dd><p><span class='case'>f., ~a, neuter</span></p><ol type='1' class='decimal'><li>(from nissāraṇa)</li><li>involving suspension; (the formal act) connected with suspension.</li><li>to be got rid of?</li></ol></dd></dl>"
     },
     {
         "word": "nissārita",
-        "text": "<dl id='nissārita'><dt><dfn>nissārita</dfn></dt><dd><p><span class='case'>pp mfn. of nissarati</span> (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissārita'><dt><dfn>nissārita</dfn></dt><dd><p><span class='case'>mfn. & n. of nissarati</span> expelled; suspended (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissārīyati",
-        "text": "<dl id='nissārīyati'><dt><dfn>nissārīyati</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nissarati</span> expels (temporarily from the <i>saṅgha</i>), suspends (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissārīyati'><dt><dfn>nissārīyati</dfn></dt><dd><p><span class='case'>pp mfn. of nissarati</span> (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissāreti",
-        "text": "<dl id='nissāreti'><dt><dfn>nissāreti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nissayati</span> resorting to, inhabiting; dependent (on); leaning on; attached to, supported by; close to, connected to; resorted to (see <i><a href='/define/nissayati'>nissayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissāreti'><dt><dfn>nissāreti</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg. of nissarati</span> expels (temporarily from the <i>saṅgha</i>), suspends (see <i><a href='/define/nissarati'>nissarati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissita",
-        "text": "<dl id='nissita'><dt data-main-entry='nissayati'><dfn>nissita</dfn></dt><dd><p><span class='case'>pp mfn.</span> speaking only what others say, relying on others’ opinions.</p></dd></dl>"
-    },
-    {
-        "word": "nissitajappin",
-        "text": "<dl id='nissitajappin'><dt><dfn>nissitajappi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> flowed out or away, vanished.</p></dd></dl>"
+        "text": "<dl id='nissita'><dt data-main-entry='nissayati'><dfn>nissita</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg. of nissayati</span> resorting to, inhabiting; dependent (on); leaning on; attached to, supported by; close to, connected to; resorted to (see <i><a href='/define/nissayati'>nissayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nissitajappi",
-        "text": "<dl id='nissitajappi'><dt><dfn>nissitajappi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> flowed out or away, vanished.</p></dd></dl>"
+        "text": "<dl id='nissitajappin'><dt><dfn>nissitajappi(n)</dfn></dt><dd><p><span class='case'>pp mfn.</span> speaking only what others say, relying on others’ opinions.</p></dd></dl>"
+    },
+    {
+        "word": "nissitajappin",
+        "text": "<dl id='nissitajappin'><dt><dfn>nissitajappi(n)</dfn></dt><dd><p><span class='case'>pp mfn.</span> speaking only what others say, relying on others’ opinions.</p></dd></dl>"
     },
     {
         "word": "nissuta",
-        "text": "<dl id='nissuta'><dt><dfn>nissuta</dfn></dt><dd><p><span class='case'>mfn.</span> ladder; a flight of steps.</p></dd></dl>"
+        "text": "<dl id='nissuta'><dt><dfn>nissuta</dfn></dt><dd><p><span class='case'>mfn.</span> flowed out or away, vanished.</p></dd></dl>"
     },
     {
         "word": "nisseṇī",
-        "text": "<dl id='nisseṇī'><dt><dfn>nisseṇī</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisseṇī'>nisseṇī</a></i>)</p></dd></dl>"
+        "text": "<dl id='nisseṇī'><dt><dfn>nisseṇī</dfn></dt><dd><p><span class='case'>mfn.</span> ladder; a flight of steps.</p></dd></dl>"
     },
     {
         "word": "nissenī",
-        "text": "<dl id='nissenī'><dt><dfn>nissenī</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nissenī'><dt><dfn>nissenī</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nisseṇī'>nisseṇī</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihacca",
-        "text": "<dl id='nihacca'><dt><dfn>nihacca</dfn></dt><dd><p><span class='case'>absol. of nihanati</span> struck, hit; struck down; destroyed, ended; put down, thrown in (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihacca'><dt><dfn>nihacca</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihata",
-        "text": "<dl id='nihata'><dt data-main-entry='nihanati'><dfn>nihata</dfn></dt><dd><p><span class='case'>pp mfn.</span> a legal question or case which has been settled.</p></dd></dl>"
+        "text": "<dl id='nihata'><dt data-main-entry='nihanati'><dfn>nihata</dfn></dt><dd><p><span class='case'>absol. of nihanati</span> struck, hit; struck down; destroyed, ended; put down, thrown in (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihatadhikaraṇa",
-        "text": "<dl id='nihatadhikaraṇa'><dt><dfn>nihatadhikaraṇa</dfn></dt><dd><p><span class='case'>neuter</span> whose enemies have been destroyed; without enemies.</p></dd></dl>"
+        "text": "<dl id='nihatadhikaraṇa'><dt><dfn>nihatadhikaraṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> a legal question or case which has been settled.</p></dd></dl>"
     },
     {
         "word": "nihatapaccāmitta",
-        "text": "<dl id='nihatapaccāmitta'><dt><dfn>nihatapaccāmitta</dfn></dt><dd><p><span class='case'>mfn.</span> free from pride.</p></dd></dl>"
+        "text": "<dl id='nihatapaccāmitta'><dt><dfn>nihatapaccāmitta</dfn></dt><dd><p><span class='case'>neuter</span> whose enemies have been destroyed; without enemies.</p></dd></dl>"
     },
     {
         "word": "nihatamāna",
-        "text": "<dl id='nihatamāna'><dt><dfn>nihatamāna</dfn></dt><dd><p><span class='case'>mfn.</span> strikes; hits, touches; throws (in); drops, lowers; knocks out, removes; destroys.</p></dd></dl>"
+        "text": "<dl id='nihatamāna'><dt><dfn>nihatamāna</dfn></dt><dd><p><span class='case'>mfn.</span> free from pride.</p></dd></dl>"
     },
     {
         "word": "nihanati",
-        "text": "<dl id='nihanati'><dt data-main-entry='nihanati'><dfn>nihanati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nihanati</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihanati'><dt data-main-entry='nihanati'><dfn>nihanati</dfn></dt><dd><p><span class='case'>mfn.</span> strikes; hits, touches; throws (in); drops, lowers; knocks out, removes; destroys.</p></dd></dl>"
     },
     {
         "word": "nihanitabba",
-        "text": "<dl id='nihanitabba'><dt><dfn>nihanitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihanitabba'><dt><dfn>nihanitabba</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nihanati</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihanti",
-        "text": "<dl id='nihanti'><dt><dfn>nihanti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nihanati</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihanti'><dt><dfn>nihanti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihantvā",
-        "text": "<dl id='nihantvā'><dt data-main-entry='nihanati'><dfn>nihantvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihantvā'><dt data-main-entry='nihanati'><dfn>nihantvā</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nihanati</span> (see <i><a href='/define/nihanati'>nihanati</a></i>)</p></dd></dl>"
     },
     {
         "word": "niharati",
-        "text": "<dl id='niharati'><dt><dfn>niharati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> to set in motion; impel.</p></dd></dl>"
+        "text": "<dl id='niharati'><dt><dfn>niharati</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihi",
-        "text": "<dl id='nihi'><dt><dfn>nihi</dfn></dt><dd><p>laid aside; (what is) deposited, stored; hidden; laid down (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihi'><dt><dfn>nihi</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> to set in motion; impel.</p></dd></dl>"
     },
     {
         "word": "nihita",
-        "text": "<dl id='nihita'><dt data-main-entry='nidahati'><dfn>nihita</dfn><sup>1</sup></dt><dd><p><span class='case'>pp mfn. of nihi</span> set in motion; impelled (see <i><a href='/define/nihi'>nihi</a></i>)</p></dd><dt><dfn>nihita</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn. of nihita</span> who has laid aside, eschewed, violence (see <i><a href='/define/nihita'>nihita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihita'><dt data-main-entry='nidahati'><dfn>nihita</dfn><sup>1</sup></dt><dd><p>laid aside; (what is) deposited, stored; hidden; laid down (see <i><a href='/define/nidahati'>nidahati</a></i>)</p></dd><dt><dfn>nihita</dfn><sup>2</sup></dt><dd><p><span class='case'>pp mfn. of nihi</span> set in motion; impelled (see <i><a href='/define/nihi'>nihi</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihitadaṇḍa",
-        "text": "<dl id='nihitadaṇḍa'><dt><dfn>nihitadaṇḍa</dfn></dt><dd><p><span class='case'>mfn.</span> setting in motion; impelling.</p></dd></dl>"
+        "text": "<dl id='nihitadaṇḍa'><dt><dfn>nihitadaṇḍa</dfn></dt><dd><p><span class='case'>pp mfn. of nihita</span> who has laid aside, eschewed, violence (see <i><a href='/define/nihita'>nihita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihiniṃ",
-        "text": "<dl id='nihiniṃ'><dt><dfn>nihiniṃ</dfn></dt><dd><p><span class='case'>aor. 1 sg. of nihīyati</span> low, base, mean; inferior; deprived of, deficient (see <i><a href='/define/nihīyati'>nihīyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nihiniṃ'><dt><dfn>nihiniṃ</dfn></dt><dd><p><span class='case'>mfn.</span> setting in motion; impelling.</p></dd></dl>"
     },
     {
         "word": "nihīna",
-        "text": "<dl id='nihīna'><dt data-main-entry='nihīyati'><dfn>nihīna</dfn></dt><dd><p><span class='case'>pp mfn.</span> associating with inferior people.</p></dd></dl>"
-    },
-    {
-        "word": "nihīnasevin",
-        "text": "<dl id='nihīnasevin'><dt><dfn>nihīnasevi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> decreases, grows less; falls away, falls short (of); is deficient.</p></dd></dl>"
+        "text": "<dl id='nihīna'><dt data-main-entry='nihīyati'><dfn>nihīna</dfn></dt><dd><p><span class='case'>aor. 1 sg. of nihīyati</span> low, base, mean; inferior; deprived of, deficient (see <i><a href='/define/nihīyati'>nihīyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nihīnasevi",
-        "text": "<dl id='nihīnasevi'><dt><dfn>nihīnasevi(n)</dfn></dt><dd><p><span class='case'>mfn.</span> decreases, grows less; falls away, falls short (of); is deficient.</p></dd></dl>"
+        "text": "<dl id='nihīnasevin'><dt><dfn>nihīnasevi(n)</dfn></dt><dd><p><span class='case'>pp mfn.</span> associating with inferior people.</p></dd></dl>"
+    },
+    {
+        "word": "nihīnasevin",
+        "text": "<dl id='nihīnasevin'><dt><dfn>nihīnasevi(n)</dfn></dt><dd><p><span class='case'>pp mfn.</span> associating with inferior people.</p></dd></dl>"
     },
     {
         "word": "nihīyati",
-        "text": "<dl id='nihīyati'><dt data-main-entry='nihīyati'><dfn>nihīyati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> affliction; destroying.</p></dd></dl>"
+        "text": "<dl id='nihīyati'><dt data-main-entry='nihīyati'><dfn>nihīyati</dfn></dt><dd><p><span class='case'>mfn.</span> decreases, grows less; falls away, falls short (of); is deficient.</p></dd></dl>"
     },
     {
         "word": "nīgha",
-        "text": "<dl id='nīgha'><dt><dfn>nīgha</dfn></dt><dd><p><span class='case'>masculine</span> low; lowly; inferior, base, mean; short.</p></dd></dl>"
+        "text": "<dl id='nīgha'><dt><dfn>nīgha</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> affliction; destroying.</p></dd></dl>"
     },
     {
         "word": "nīca",
-        "text": "<dl id='nīca'><dt><dfn>nīca</dfn></dt><dd><p><span class='case'>mfn.</span> lowers; belittles.</p></dd></dl>"
+        "text": "<dl id='nīca'><dt><dfn>nīca</dfn></dt><dd><p><span class='case'>masculine</span> low; lowly; inferior, base, mean; short.</p></dd></dl>"
     },
     {
         "word": "nīcaṃ karoti",
-        "text": "<dl id='nīcaṃ karoti'><dt><dfn>nīcaṃ karoti</dfn></dt><dd><p>a family of low rank.</p></dd></dl>"
+        "text": "<dl id='nīcaṃ karoti'><dt><dfn>nīcaṃ karoti</dfn></dt><dd><p><span class='case'>mfn.</span> lowers; belittles.</p></dd></dl>"
     },
     {
         "word": "nīcakula",
-        "text": "<dl id='nīcakula'><dt><dfn>nīcakula</dfn></dt><dd><p><span class='case'>feminine</span> born in a family of low rank.</p></dd></dl>"
+        "text": "<dl id='nīcakula'><dt><dfn>nīcakula</dfn></dt><dd><p>a family of low rank.</p></dd></dl>"
     },
     {
         "word": "nīcakulīna",
-        "text": "<dl id='nīcakulīna'><dt><dfn>nīcakulīna</dfn></dt><dd><p><span class='case'>mfn.</span> lower; shorter.</p></dd></dl>"
+        "text": "<dl id='nīcakulīna'><dt><dfn>nīcakulīna</dfn></dt><dd><p><span class='case'>feminine</span> born in a family of low rank.</p></dd></dl>"
     },
     {
         "word": "nīcatara",
-        "text": "<dl id='nīcatara'><dt><dfn>nīcatara</dfn></dt><dd><p><span class='case'>mfn.</span> compar., lower; shorter.</p></dd></dl>"
+        "text": "<dl id='nīcatara'><dt><dfn>nīcatara</dfn></dt><dd><p><span class='case'>mfn.</span> lower; shorter.</p></dd></dl>"
     },
     {
         "word": "nīcataraṃ",
-        "text": "<dl id='nīcataraṃ'><dt><dfn>nīcataraṃ</dfn></dt><dd><p><span class='case'>adverb</span> intent upon lowly things; humble.</p></dd></dl>"
+        "text": "<dl id='nīcataraṃ'><dt><dfn>nīcataraṃ</dfn></dt><dd><p><span class='case'>mfn.</span> compar., lower; shorter.</p></dd></dl>"
     },
     {
         "word": "nīcaniviṭṭha",
-        "text": "<dl id='nīcaniviṭṭha'><dt><dfn>nīcaniviṭṭha</dfn></dt><dd><p><span class='case'>mfn.</span> with a low platform, on a low site.</p></dd></dl>"
+        "text": "<dl id='nīcaniviṭṭha'><dt><dfn>nīcaniviṭṭha</dfn></dt><dd><p><span class='case'>adverb</span> intent upon lowly things; humble.</p></dd></dl>"
     },
     {
         "word": "nīcavatthuka",
-        "text": "<dl id='nīcavatthuka'><dt><dfn>nīcavatthuka</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nīcakulīna'>nīcakulīna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīcavatthuka'><dt><dfn>nīcavatthuka</dfn></dt><dd><p><span class='case'>mfn.</span> with a low platform, on a low site.</p></dd></dl>"
     },
     {
         "word": "nīcākulīna",
-        "text": "<dl id='nīcākulīna'><dt><dfn>nīcākulīna</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>(mfn.) lower, inferior.</li><li>(n.) lowness; inferiority.</li></ol></dd></dl>"
+        "text": "<dl id='nīcākulīna'><dt><dfn>nīcākulīna</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nīcakulīna'>nīcakulīna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīcceyya",
-        "text": "<dl id='nīcceyya'><dt><dfn>nīcceyya</dfn></dt><dd><p><span class='case'>mfn. & n. of nayati</span> led, brought to; brought to a state; taken away; carried off (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīcceyya'><dt><dfn>nīcceyya</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>(mfn.) lower, inferior.</li><li>(n.) lowness; inferiority.</li></ol></dd></dl>"
     },
     {
         "word": "nīta",
-        "text": "<dl id='nīta'><dt data-main-entry='neti'><dfn>nīta</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose meaning is brought out, determined, evident, explicit.</p></dd></dl>"
+        "text": "<dl id='nīta'><dt data-main-entry='neti'><dfn>nīta</dfn></dt><dd><p><span class='case'>mfn. & n. of nayati</span> led, brought to; brought to a state; taken away; carried off (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nītattha",
-        "text": "<dl id='nītattha'><dt><dfn>nītattha</dfn></dt><dd><p><span class='case'>mfn.</span> is led (away); is taken off; is determined, is interpreted (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nītattha'><dt><dfn>nītattha</dfn></dt><dd><p><span class='case'>pp mfn.</span> whose meaning is brought out, determined, evident, explicit.</p></dd></dl>"
     },
     {
         "word": "nīyati",
-        "text": "<dl id='nīyati'><dt data-main-entry='neti'><dfn>nīyati</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīyati'><dt data-main-entry='neti'><dfn>nīyati</dfn></dt><dd><p><span class='case'>mfn.</span> is led (away); is taken off; is determined, is interpreted (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīyāti",
-        "text": "<dl id='nīyāti'><dt><dfn>nīyāti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyānta</span> (see <i><a href='/define/niyyānta'>niyyānta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīyāti'><dt><dfn>nīyāti</dfn></dt><dd><p><span class='case'>pass. pr. 3 sg.</span> (see <i><a href='/define/niyyāti'>niyyāti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīyanta",
-        "text": "<dl id='nīyanta'><dt><dfn>nīyanta</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nīyati</span> (see <i><a href='/define/nīyati'>nīyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīyanta'><dt><dfn>nīyanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niyyānta</span> (see <i><a href='/define/niyyānta'>niyyānta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīyamāna",
-        "text": "<dl id='nīyamāna'><dt><dfn>nīyamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāyanta</span> (see <i><a href='/define/niyyāyanta'>niyyāyanta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīyamāna'><dt><dfn>nīyamāna</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nīyati</span> (see <i><a href='/define/nīyati'>nīyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīyāyanta",
-        "text": "<dl id='nīyāyanta'><dt><dfn>nīyāyanta</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/niyyāna'>niyyāna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīyāyanta'><dt><dfn>nīyāyanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of niyyāyanta</span> (see <i><a href='/define/niyyāyanta'>niyyāyanta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīyyāṇa",
-        "text": "<dl id='nīyyāṇa'><dt><dfn>nīyyāṇa</dfn></dt><dd><p><span class='case'>neuter</span></p><ol type='1' class='decimal'><li>(mfn.) of a dark color, esp. dark blue, </li><li>(n.) a blue-green substance or dye or mineral; blue-black; dark green; blue-green.</li></ol></dd></dl>"
+        "text": "<dl id='nīyyāṇa'><dt><dfn>nīyyāṇa</dfn></dt><dd><p><span class='case'>part. pr. mfn.</span> (see <i><a href='/define/niyyāna'>niyyāna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīla",
-        "text": "<dl id='nīla'><dt><dfn>nīla</dfn></dt><dd><p><span class='case'>mfn.</span> the blue-green class of beings.</p></dd></dl>"
+        "text": "<dl id='nīla'><dt><dfn>nīla</dfn></dt><dd><p><span class='case'>neuter</span></p><ol type='1' class='decimal'><li>(mfn.) of a dark color, esp. dark blue, </li><li>(n.) a blue-green substance or dye or mineral; blue-black; dark green; blue-green.</li></ol></dd></dl>"
     },
     {
         "word": "nīlabhijāti",
-        "text": "<dl id='nīlabhijāti'><dt><dfn>nīlabhijāti</dfn></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li>(mfn.) of a dark color, esp. dark-blue, blue-black; dark green; blue-green.</li><li>(n.) a dark blue, blue-black dye.</li></ol></dd></dl>"
+        "text": "<dl id='nīlabhijāti'><dt><dfn>nīlabhijāti</dfn></dt><dd><p><span class='case'>mfn.</span> the blue-green class of beings.</p></dd></dl>"
     },
     {
         "word": "nīlaka",
-        "text": "<dl id='nīlaka'><dt><dfn>nīlaka</dfn></dt><dd><p><span class='case'>mfn. & ~ā, f</span> with dark-blue straps.</p></dd></dl>"
+        "text": "<dl id='nīlaka'><dt><dfn>nīlaka</dfn></dt><dd><p><span class='case'>feminine</span></p><ol type='1' class='decimal'><li>(mfn.) of a dark color, esp. dark-blue, blue-black; dark green; blue-green.</li><li>(n.) a dark blue, blue-black dye.</li></ol></dd></dl>"
     },
     {
         "word": "nīlakavaddhika",
-        "text": "<dl id='nīlakavaddhika'><dt><dfn>nīlakavaddhika</dfn></dt><dd><p><span class='case'>mfn.</span> meditation based on (something) dark blue; a dark blue meditation object; (the jhana) which is or is brought about by meditation based on (something) dark blue.</p></dd></dl>"
+        "text": "<dl id='nīlakavaddhika'><dt><dfn>nīlakavaddhika</dfn></dt><dd><p><span class='case'>mfn. & ~ā, f</span> with dark-blue straps.</p></dd></dl>"
     },
     {
         "word": "nīlakasiṇa",
-        "text": "<dl id='nīlakasiṇa'><dt><dfn>nīlakasiṇa</dfn></dt><dd><p><span class='case'>neuter</span> blue-necked; a peacock.</p></dd></dl>"
+        "text": "<dl id='nīlakasiṇa'><dt><dfn>nīlakasiṇa</dfn></dt><dd><p><span class='case'>mfn.</span> meditation based on (something) dark blue; a dark blue meditation object; (the jhana) which is or is brought about by meditation based on (something) dark blue.</p></dd></dl>"
     },
     {
         "word": "nīlagiva",
-        "text": "<dl id='nīlagiva'><dt><dfn>nīlagiva</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> of dark-blue appearance or luster.</p></dd></dl>"
+        "text": "<dl id='nīlagiva'><dt><dfn>nīlagiva</dfn></dt><dd><p><span class='case'>neuter</span> blue-necked; a peacock.</p></dd></dl>"
     },
     {
         "word": "nīlanibhāsa",
-        "text": "<dl id='nīlanibhāsa'><dt><dfn>nīlanibhāsa</dfn></dt><dd><p><span class='case'>mfn.</span> with dark-blue straps.</p></dd></dl>"
+        "text": "<dl id='nīlanibhāsa'><dt><dfn>nīlanibhāsa</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> of dark-blue appearance or luster.</p></dd></dl>"
     },
     {
         "word": "nīlavadhika",
-        "text": "<dl id='nīlavadhika'><dt><dfn>nīlavadhika</dfn></dt><dd><p><span class='case'>mfn.</span> the indigo plant or dye.</p></dd></dl>"
+        "text": "<dl id='nīlavadhika'><dt><dfn>nīlavadhika</dfn></dt><dd><p><span class='case'>mfn.</span> with dark-blue straps.</p></dd></dl>"
     },
     {
         "word": "nīlī",
-        "text": "<dl id='nīlī'><dt><dfn>nīlī</dfn></dt><dd><p><span class='case'>feminine</span> an obstacle, a hindrance (esp. five: <i>kāmacchanda</i>, <i>vyāpāda</i>, <i>thīnamiddha</i>, <i>uddhaccakukkucca</i>, <i>vicikicchā</i>); being a hindrance, which is an obstacle.</p></dd></dl>"
+        "text": "<dl id='nīlī'><dt><dfn>nīlī</dfn></dt><dd><p><span class='case'>mfn.</span> the indigo plant or dye.</p></dd></dl>"
     },
     {
         "word": "nīvaraṇa",
-        "text": "<dl id='nīvaraṇa'><dt><dfn>nīvaraṇa</dfn></dt><dd><p><span class='case'>neuter</span> eating wild rice.</p></dd></dl>"
+        "text": "<dl id='nīvaraṇa'><dt><dfn>nīvaraṇa</dfn></dt><dd><p><span class='case'>feminine</span> an obstacle, a hindrance (esp. five: <i>kāmacchanda</i>, <i>vyāpāda</i>, <i>thīnamiddha</i>, <i>uddhaccakukkucca</i>, <i>vicikicchā</i>); being a hindrance, which is an obstacle.</p></dd></dl>"
     },
     {
         "word": "nīvārabhakka",
-        "text": "<dl id='nīvārabhakka'><dt><dfn>nīvārabhakka</dfn></dt><dd><p><span class='case'>mfn.</span> taken out, brought out; driven out; expelled (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīvārabhakka'><dt><dfn>nīvārabhakka</dfn></dt><dd><p><span class='case'>neuter</span> eating wild rice.</p></dd></dl>"
     },
     {
         "word": "nīhaṭa",
-        "text": "<dl id='nīhaṭa'><dt data-main-entry='nīharati'><dfn>nīhaṭa</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nīhāṭa'>nīhāṭa</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīhaṭa'><dt data-main-entry='nīharati'><dfn>nīhaṭa</dfn></dt><dd><p><span class='case'>mfn.</span> taken out, brought out; driven out; expelled (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīhata",
-        "text": "<dl id='nīhata'><dt><dfn>nīhata</dfn></dt><dd><p><span class='case'>pp mfn.</span> takes out, extracts; extricates; draws out; carries out; removes; drives out, expels.</p></dd></dl>"
+        "text": "<dl id='nīhata'><dt><dfn>nīhata</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nīhāṭa'>nīhāṭa</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīharati",
-        "text": "<dl id='nīharati'><dt data-main-entry='nīharati'><dfn>nīharati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīharati'><dt data-main-entry='nīharati'><dfn>nīharati</dfn></dt><dd><p><span class='case'>pp mfn.</span> takes out, extracts; extricates; draws out; carries out; removes; drives out, expels.</p></dd></dl>"
     },
     {
         "word": "nīharanta",
-        "text": "<dl id='nīharanta'><dt data-main-entry='nīharati'><dfn>nīharanta</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīharanta'><dt data-main-entry='nīharati'><dfn>nīharanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīhari",
-        "text": "<dl id='nīhari'><dt data-main-entry='nīharati'><dfn>nīhari</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīhari'><dt data-main-entry='nīharati'><dfn>nīhari</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīhariṃsu",
-        "text": "<dl id='nīhariṃsu'><dt><dfn>nīhariṃsu</dfn></dt><dd><p><span class='case'>3 pl. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīhariṃsu'><dt><dfn>nīhariṃsu</dfn></dt><dd><p><span class='case'>aor. 3 sg. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīharitabba",
-        "text": "<dl id='nīharitabba'><dt><dfn>nīharitabba</dfn></dt><dd><p><span class='case'>absol. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīharitabba'><dt><dfn>nīharitabba</dfn></dt><dd><p><span class='case'>3 pl. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīharittha",
-        "text": "<dl id='nīharittha'><dt><dfn>nīharittha</dfn></dt><dd><p><span class='case'>2 pl. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīharittha'><dt><dfn>nīharittha</dfn></dt><dd><p><span class='case'>absol. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīharitvā",
-        "text": "<dl id='nīharitvā'><dt data-main-entry='nīharati'><dfn>nīharitvā</dfn></dt><dd><p><span class='case'>absol. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīharitvā'><dt data-main-entry='nīharati'><dfn>nīharitvā</dfn></dt><dd><p><span class='case'>2 pl. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīhātuṃ",
-        "text": "<dl id='nīhātuṃ'><dt><dfn>nīhātuṃ</dfn></dt><dd><p><span class='case'>inf.</span> for whom food has been brought.</p></dd></dl>"
+        "text": "<dl id='nīhātuṃ'><dt><dfn>nīhātuṃ</dfn></dt><dd><p><span class='case'>absol. of nīharati</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nīhārabhatta",
-        "text": "<dl id='nīhārabhatta'><dt><dfn>nīhārabhatta</dfn></dt><dd><p><span class='case'>mfn.</span> will take out, extract; will extricate; will draw out; will carry out; will remove; will drive out, expel.</p></dd></dl>"
+        "text": "<dl id='nīhārabhatta'><dt><dfn>nīhārabhatta</dfn></dt><dd><p><span class='case'>inf.</span> for whom food has been brought.</p></dd></dl>"
     },
     {
         "word": "nīhārāpetabba",
-        "text": "<dl id='nīhārāpetabba'><dt><dfn>nīhārāpetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> will take out, extract; will extricate; will draw out; will carry out; will remove; will drive out, expel.</p></dd></dl>"
+        "text": "<dl id='nīhārāpetabba'><dt><dfn>nīhārāpetabba</dfn></dt><dd><p><span class='case'>mfn.</span> will take out, extract; will extricate; will draw out; will carry out; will remove; will drive out, expel.</p></dd></dl>"
     },
     {
         "word": "nīhāritabba",
-        "text": "<dl id='nīhāritabba'><dt><dfn>nīhāritabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nīhāritabba'><dt><dfn>nīhāritabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> will take out, extract; will extricate; will draw out; will carry out; will remove; will drive out, expel.</p></dd></dl>"
     },
     {
         "word": "nīhārituṃ",
-        "text": "<dl id='nīhārituṃ'><dt><dfn>nīhārituṃ</dfn></dt><dd><p><span class='case'>inf.</span></p><ol type='1' class='decimal'><li>an emphatic particle (very often followed by <i>kho</i>):</li><li>indeed; surely.</li><li><ol type='i' class='lower-roman'><li>by itself.</li><li>combined with an interrogative pronoun or adverb.</li><li>in double questions (repeated, or followed by another particle)</li></ol></li></ol></dd></dl>"
+        "text": "<dl id='nīhārituṃ'><dt><dfn>nīhārituṃ</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nīharati'>nīharati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nu",
-        "text": "<dl id='nu'><dt><dfn>nu</dfn></dt><dd><p><span class='case'>ind.</span> (see <i><a href='/define/nudati'>nudati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nu'><dt><dfn>nu</dfn></dt><dd><p><span class='case'>inf.</span></p><ol type='1' class='decimal'><li>an emphatic particle (very often followed by <i>kho</i>):</li><li>indeed; surely.</li><li><ol type='i' class='lower-roman'><li>by itself.</li><li>combined with an interrogative pronoun or adverb.</li><li>in double questions (repeated, or followed by another particle)</li></ol></li></ol></dd></dl>"
     },
     {
         "word": "nujjati",
-        "text": "<dl id='nujjati'><dt><dfn>nujjati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nujjati'><dt><dfn>nujjati</dfn></dt><dd><p><span class='case'>ind.</span> (see <i><a href='/define/nudati'>nudati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nuṭṭhubhati",
-        "text": "<dl id='nuṭṭhubhati'><dt><dfn>nuṭṭhubhati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nuṭṭhubhati'><dt><dfn>nuṭṭhubhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nuṭṭhubhitvā",
-        "text": "<dl id='nuṭṭhubhitvā'><dt><dfn>nuṭṭhubhitvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nuṭṭhubhitvā'><dt><dfn>nuṭṭhubhitvā</dfn></dt><dd><p><span class='case'>pr. 3 sg. of niṭṭhubhati</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nuṭṭhuhati",
-        "text": "<dl id='nuṭṭhuhati'><dt><dfn>nuṭṭhuhati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nunna'>nunna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nuṭṭhuhati'><dt><dfn>nuṭṭhuhati</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/niṭṭhubhati'>niṭṭhubhati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nuṇṇa",
-        "text": "<dl id='nuṇṇa'><dt data-main-entry='nudati'><dfn>nuṇṇa</dfn></dt><dd><p><span class='case'>pp mfn.</span> impels, pushes; drives away, dispels; removes.</p></dd></dl>"
+        "text": "<dl id='nuṇṇa'><dt data-main-entry='nudati'><dfn>nuṇṇa</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nunna'>nunna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nudati",
-        "text": "<dl id='nudati'><dt data-main-entry='nudati'><dfn>nudati</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nudati'>nudati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nudati'><dt data-main-entry='nudati'><dfn>nudati</dfn></dt><dd><p><span class='case'>pp mfn.</span> impels, pushes; drives away, dispels; removes.</p></dd></dl>"
     },
     {
         "word": "nudeti",
-        "text": "<dl id='nudeti'><dt><dfn>nudeti</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nudeti</span> impelled; driven away, dispelled, removed (see <i><a href='/define/nudeti'>nudeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nudeti'><dt><dfn>nudeti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span> (see <i><a href='/define/nudati'>nudati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nunna",
-        "text": "<dl id='nunna'><dt><dfn>nunna</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>indeed; certainly.</li><li>surely; probably, in all probability; it must be that …</li><li>is it that?; esp. <i>yam</i> + <i>nūna</i> + opt.: what if …? suppose …? why don’t …?</li></ol></dd></dl>"
+        "text": "<dl id='nunna'><dt><dfn>nunna</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nudeti</span> impelled; driven away, dispelled, removed (see <i><a href='/define/nudeti'>nudeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nūna",
-        "text": "<dl id='nūna'><dt><dfn>nūna</dfn></dt><dd><p><span class='case'>ind. of na</span> (see <i><a href='/define/na'>na</a></i>)</p></dd></dl>"
+        "text": "<dl id='nūna'><dt><dfn>nūna</dfn></dt><dd><p><span class='case'>pp mfn.</span></p><ol type='1' class='decimal'><li>indeed; certainly.</li><li>surely; probably, in all probability; it must be that …</li><li>is it that?; esp. <i>yam</i> + <i>nūna</i> + opt.: what if …? suppose …? why don’t …?</li></ol></dd></dl>"
     },
     {
         "word": "ne",
-        "text": "<dl id='ne'><dt><dfn>ne</dfn></dt><dd><p><span class='case'>pl. acc</span> (pl. gen. <i>~ānaṃ</i>, <i>~esaṃ</i>), not one, more than one; many; various.</p></dd></dl>"
+        "text": "<dl id='ne'><dt><dfn>ne</dfn></dt><dd><p><span class='case'>ind. of na</span> (see <i><a href='/define/na'>na</a></i>)</p></dd></dl>"
     },
     {
         "word": "neka",
-        "text": "<dl id='neka'><dt><dfn>neka</dfn></dt><dd><p><span class='case'>mfn.</span> dishonest; practicing fraud.</p></dd></dl>"
+        "text": "<dl id='neka'><dt><dfn>neka</dfn></dt><dd><p><span class='case'>pl. acc</span> (pl. gen. <i>~ānaṃ</i>, <i>~esaṃ</i>), not one, more than one; many; various.</p></dd></dl>"
     },
     {
         "word": "nekatika",
-        "text": "<dl id='nekatika'><dt><dfn>nekatika</dfn></dt><dd><p><span class='case'>mfn.</span> in many ways; many ways (see <i><a href='/define/neka'>neka</a></i>)</p></dd></dl>"
+        "text": "<dl id='nekatika'><dt><dfn>nekatika</dfn></dt><dd><p><span class='case'>mfn.</span> dishonest; practicing fraud.</p></dd></dl>"
     },
     {
         "word": "nekadhā",
-        "text": "<dl id='nekadhā'><dt><dfn>nekadhā</dfn></dt><dd><p><span class='case'>adverb of neka</span> in existence for many years; produced over many years (see <i><a href='/define/neka'>neka</a></i>)</p></dd></dl>"
+        "text": "<dl id='nekadhā'><dt><dfn>nekadhā</dfn></dt><dd><p><span class='case'>mfn.</span> in many ways; many ways (see <i><a href='/define/neka'>neka</a></i>)</p></dd></dl>"
     },
     {
         "word": "nekavassagaṇika",
-        "text": "<dl id='nekavassagaṇika'><dt><dfn>nekavassagaṇika</dfn></dt><dd><p><span class='case'>mfn.</span> made of gold; gold; a coin or ornament made of gold.</p></dd></dl>"
+        "text": "<dl id='nekavassagaṇika'><dt><dfn>nekavassagaṇika</dfn></dt><dd><p><span class='case'>adverb of neka</span> in existence for many years; produced over many years (see <i><a href='/define/neka'>neka</a></i>)</p></dd></dl>"
     },
     {
         "word": "nekkha",
-        "text": "<dl id='nekkha'><dt><dfn>nekkha</dfn></dt><dd><p><span class='case'>mfn. & neuter</span> departure from worldly life; the renunciation of worldly things and values; whatever is the opposite of or rejection of all worldly, sensual experience and desires.</p></dd></dl>"
+        "text": "<dl id='nekkha'><dt><dfn>nekkha</dfn></dt><dd><p><span class='case'>mfn.</span> made of gold; gold; a coin or ornament made of gold.</p></dd></dl>"
     },
     {
         "word": "nekkhamma",
-        "text": "<dl id='nekkhamma'><dt><dfn>nekkhamma</dfn></dt><dd><p><span class='case'>neuter</span> the domain of renunciation; renunciation.</p></dd></dl>"
+        "text": "<dl id='nekkhamma'><dt><dfn>nekkhamma</dfn></dt><dd><p><span class='case'>mfn. & neuter</span> departure from worldly life; the renunciation of worldly things and values; whatever is the opposite of or rejection of all worldly, sensual experience and desires.</p></dd></dl>"
     },
     {
         "word": "nekkhammadhatu",
-        "text": "<dl id='nekkhammadhatu'><dt><dfn>nekkhammadhatu</dfn></dt><dd><p><span class='case'>feminine</span> connected with, attached to, rooted in, the of renunciation; appropriate (only) to the life of renunciation.</p></dd></dl>"
+        "text": "<dl id='nekkhammadhatu'><dt><dfn>nekkhammadhatu</dfn></dt><dd><p><span class='case'>neuter</span> the domain of renunciation; renunciation.</p></dd></dl>"
     },
     {
         "word": "nekkhammasita",
-        "text": "<dl id='nekkhammasita'><dt><dfn>nekkhammasita</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>(one) who lives in a small town; a townsman; a (leading) trader or merchant.</li><li>the inhabitants of a small town; the townspeople.</li></ol></dd></dl>"
+        "text": "<dl id='nekkhammasita'><dt><dfn>nekkhammasita</dfn></dt><dd><p><span class='case'>feminine</span> connected with, attached to, rooted in, the of renunciation; appropriate (only) to the life of renunciation.</p></dd></dl>"
     },
     {
         "word": "negama",
-        "text": "<dl id='negama'><dt><dfn>negama</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/negamajānapada'>negamajānapada</a></i>)</p></dd></dl>"
+        "text": "<dl id='negama'><dt><dfn>negama</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='1' class='decimal'><li>(one) who lives in a small town; a townsman; a (leading) trader or merchant.</li><li>the inhabitants of a small town; the townspeople.</li></ol></dd></dl>"
     },
     {
         "word": "negamajanapada",
-        "text": "<dl id='negamajanapada'><dt><dfn>negamajanapada</dfn></dt><dd><p><span class='case'>masculine & ~a, masculine plural</span> townspeople and country people.</p></dd></dl>"
+        "text": "<dl id='negamajanapada'><dt><dfn>negamajanapada</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> (see <i><a href='/define/negamajānapada'>negamajānapada</a></i>)</p></dd></dl>"
     },
     {
         "word": "negamajānapada",
-        "text": "<dl id='negamajānapada'><dt><dfn>negamajānapada</dfn></dt><dd><p><span class='case'>masculine & ~a, masculine plural</span> (one) who accumulates, who stores up.</p></dd></dl>"
+        "text": "<dl id='negamajānapada'><dt><dfn>negamajānapada</dfn></dt><dd><p><span class='case'>masculine & ~a, masculine plural</span> townspeople and country people.</p></dd></dl>"
     },
     {
         "word": "necayika",
-        "text": "<dl id='necayika'><dt><dfn>necayika</dfn></dt><dd><p><span class='case'>mfn.</span> to be led or brought; to be carried on; to be brought forward; to be adduced (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='necayika'><dt><dfn>necayika</dfn></dt><dd><p><span class='case'>masculine & ~a, masculine plural</span> (one) who accumulates, who stores up.</p></dd></dl>"
     },
     {
         "word": "netabba",
-        "text": "<dl id='netabba'><dt data-main-entry='neti'><dfn>netabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> it is (not) the case; it is (not) possible (see <i><a href='/define/ṭhāna'>ṭhāna</a></i>)</p></dd></dl>"
+        "text": "<dl id='netabba'><dt data-main-entry='neti'><dfn>netabba</dfn></dt><dd><p><span class='case'>mfn.</span> to be led or brought; to be carried on; to be brought forward; to be adduced (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "netaṃ ṭhānaṃ vijjati",
-        "text": "<dl id='netaṃ ṭhānaṃ vijjati'><dt><dfn>netaṃ ṭhānaṃ vijjati</dfn></dt><dd><p>one who takes, who leads; a leader; a guide.</p></dd></dl>"
-    },
-    {
-        "word": "netar",
-        "text": "<dl id='netar'><dt><dfn>neta(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='netaṃ ṭhānaṃ vijjati'><dt><dfn>netaṃ ṭhānaṃ vijjati</dfn></dt><dd><p><span class='case'>fpp mfn.</span> it is (not) the case; it is (not) possible (see <i><a href='/define/ṭhāna'>ṭhāna</a></i>)</p></dd></dl>"
     },
     {
         "word": "neta",
-        "text": "<dl id='neta'><dt><dfn>neta(r)</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='netar'><dt><dfn>neta(r)</dfn></dt><dd><p>one who takes, who leads; a leader; a guide.</p></dd></dl>"
+    },
+    {
+        "word": "netar",
+        "text": "<dl id='netar'><dt><dfn>neta(r)</dfn></dt><dd><p>one who takes, who leads; a leader; a guide.</p></dd></dl>"
     },
     {
         "word": "neti",
-        "text": "<dl id='neti'><dt data-main-entry='neti'><dfn>neti</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>a leader.</li><li>the eye.</li><li>a leading rein.</li></ol></dd></dl>"
+        "text": "<dl id='neti'><dt data-main-entry='neti'><dfn>neti</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "netta",
-        "text": "<dl id='netta'><dt><dfn>netta</dfn></dt><dd><p><span class='case'>neuter</span> (applying) eye-salve, eye-ointment.</p></dd></dl>"
+        "text": "<dl id='netta'><dt><dfn>netta</dfn></dt><dd><p><span class='case'>pr. 3 sg.</span></p><ol type='1' class='decimal'><li>a leader.</li><li>the eye.</li><li>a leading rein.</li></ol></dd></dl>"
     },
     {
         "word": "nettatappana",
-        "text": "<dl id='nettatappana'><dt><dfn>nettatappana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/netta'>netta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nettatappana'><dt><dfn>nettatappana</dfn></dt><dd><p><span class='case'>neuter</span> (applying) eye-salve, eye-ointment.</p></dd></dl>"
     },
     {
         "word": "nettar",
-        "text": "<dl id='nettar'><dt><dfn>netta(r)</dfn></dt><dd><p><span class='case'>neuter</span> one who makes conduits for irrigation.</p></dd></dl>"
+        "text": "<dl id='nettar'><dt><dfn>netta(r)</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/netta'>netta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nettika",
-        "text": "<dl id='nettika'><dt><dfn>nettika</dfn></dt><dd><p><span class='case'>masculine</span> who has cut the rope (of craving)</p></dd></dl>"
+        "text": "<dl id='nettika'><dt><dfn>nettika</dfn></dt><dd><p><span class='case'>neuter</span> one who makes conduits for irrigation.</p></dd></dl>"
     },
     {
         "word": "nettucchinna",
-        "text": "<dl id='nettucchinna'><dt><dfn>nettucchinna</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/netta'>netta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nettucchinna'><dt><dfn>nettucchinna</dfn></dt><dd><p><span class='case'>masculine</span> who has cut the rope (of craving)</p></dd></dl>"
     },
     {
         "word": "netra",
-        "text": "<dl id='netra'><dt><dfn>netra</dfn></dt><dd><p><span class='case'>neuter</span> crossing; release; acquittance.</p></dd></dl>"
+        "text": "<dl id='netra'><dt><dfn>netra</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/netta'>netta</a></i>)</p></dd></dl>"
     },
     {
         "word": "netthāra",
-        "text": "<dl id='netthāra'><dt><dfn>netthāra</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='netthāra'><dt><dfn>netthāra</dfn></dt><dd><p><span class='case'>neuter</span> crossing; release; acquittance.</p></dd></dl>"
     },
     {
         "word": "netvā",
-        "text": "<dl id='netvā'><dt data-main-entry='neti'><dfn>netvā</dfn></dt><dd><p><span class='case'>absol. of nayati</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='netvā'><dt data-main-entry='neti'><dfn>netvā</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "netvāna",
-        "text": "<dl id='netvāna'><dt><dfn>netvāna</dfn></dt><dd><p><span class='case'>absol.</span> the lower, buried, half.</p></dd></dl>"
+        "text": "<dl id='netvāna'><dt><dfn>netvāna</dfn></dt><dd><p><span class='case'>absol. of nayati</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nema",
-        "text": "<dl id='nema'><dt><dfn>nema</dfn></dt><dd><p><span class='case'>masculine</span> (from nimantana) (one) who accepts invitations (to meals)</p></dd></dl>"
+        "text": "<dl id='nema'><dt><dfn>nema</dfn></dt><dd><p><span class='case'>absol.</span> the lower, buried, half.</p></dd></dl>"
     },
     {
         "word": "nemantaṇika",
-        "text": "<dl id='nemantaṇika'><dt><dfn>nemantaṇika</dfn></dt><dd><p><span class='case'>m(fn).</span> (see <i><a href='/define/nemantanika'>nemantanika</a></i>)</p></dd></dl>"
+        "text": "<dl id='nemantaṇika'><dt><dfn>nemantaṇika</dfn></dt><dd><p><span class='case'>masculine</span> (from nimantana) (one) who accepts invitations (to meals)</p></dd></dl>"
     },
     {
         "word": "nemantanika",
-        "text": "<dl id='nemantanika'><dt><dfn>nemantanika</dfn></dt><dd><p><span class='case'>m(fn).</span> the rim of a wheel; a rim.</p></dd></dl>"
+        "text": "<dl id='nemantanika'><dt><dfn>nemantanika</dfn></dt><dd><p><span class='case'>m(fn).</span> (see <i><a href='/define/nemantanika'>nemantanika</a></i>)</p></dd></dl>"
     },
     {
         "word": "nemi",
-        "text": "<dl id='nemi'><dt><dfn>nemi</dfn></dt><dd><p><span class='case'>feminine</span> (one) who interprets signs or omens.</p></dd></dl>"
+        "text": "<dl id='nemi'><dt><dfn>nemi</dfn></dt><dd><p><span class='case'>m(fn).</span> the rim of a wheel; a rim.</p></dd></dl>"
     },
     {
         "word": "nemitta",
-        "text": "<dl id='nemitta'><dt><dfn>nemitta</dfn></dt><dd><p><span class='case'>m(fn).</span> (see <i><a href='/define/nemittika'>nemittika</a></i>)</p></dd></dl>"
+        "text": "<dl id='nemitta'><dt><dfn>nemitta</dfn></dt><dd><p><span class='case'>feminine</span> (one) who interprets signs or omens.</p></dd></dl>"
     },
     {
         "word": "nemittaka",
-        "text": "<dl id='nemittaka'><dt><dfn>nemittaka</dfn></dt><dd><p><span class='case'>masculine</span> one who drops hints (for gain)</p></dd></dl>"
+        "text": "<dl id='nemittaka'><dt><dfn>nemittaka</dfn></dt><dd><p><span class='case'>m(fn).</span> (see <i><a href='/define/nemittika'>nemittika</a></i>)</p></dd></dl>"
     },
     {
         "word": "nemittika",
-        "text": "<dl id='nemittika'><dt><dfn>nemittika</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nemi'>nemi</a></i>)</p></dd></dl>"
+        "text": "<dl id='nemittika'><dt><dfn>nemittika</dfn></dt><dd><p><span class='case'>masculine</span> one who drops hints (for gain)</p></dd></dl>"
     },
     {
         "word": "nemī",
-        "text": "<dl id='nemī'><dt><dfn>nemī</dfn></dt><dd><p><span class='case'>feminine</span> to be led, to be brought to (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nemī'><dt><dfn>nemī</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nemi'>nemi</a></i>)</p></dd></dl>"
     },
     {
         "word": "neyya",
-        "text": "<dl id='neyya'><dt><dfn>neyya</dfn></dt><dd><p><span class='case'>fpp mfn.</span> whose meaning is not evident or straightforward, but requires interpretation or bringing out.</p></dd></dl>"
+        "text": "<dl id='neyya'><dt><dfn>neyya</dfn></dt><dd><p><span class='case'>feminine</span> to be led, to be brought to (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "neyyattha",
-        "text": "<dl id='neyyattha'><dt><dfn>neyyattha</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='i' class='lower-roman'><li>(someone) living, suffering in hell.</li><li>(one) doomed to suffer in niraya.</li></ol></dd></dl>"
+        "text": "<dl id='neyyattha'><dt><dfn>neyyattha</dfn></dt><dd><p><span class='case'>fpp mfn.</span> whose meaning is not evident or straightforward, but requires interpretation or bringing out.</p></dd></dl>"
     },
     {
         "word": "nerayika",
-        "text": "<dl id='nerayika'><dt><dfn>nerayika</dfn></dt><dd><p><span class='case'>mfn. & m.f.</span> (according to commentaries) without fault; pure.</p></dd></dl>"
+        "text": "<dl id='nerayika'><dt><dfn>nerayika</dfn></dt><dd><p><span class='case'>mfn.</span></p><ol type='i' class='lower-roman'><li>(someone) living, suffering in hell.</li><li>(one) doomed to suffer in niraya.</li></ol></dd></dl>"
     },
     {
         "word": "nela",
-        "text": "<dl id='nela'><dt><dfn>nela</dfn></dt><dd><p><span class='case'>mfn.</span> whose parts are faultless; whose frame is smooth or polished; ? (see <i><a href='/define/nela'>nela</a></i>)</p></dd></dl>"
+        "text": "<dl id='nela'><dt><dfn>nela</dfn></dt><dd><p><span class='case'>mfn. & m.f.</span> (according to commentaries) without fault; pure.</p></dd></dl>"
     },
     {
         "word": "nelaṅga",
-        "text": "<dl id='nelaṅga'><dt><dfn>nelaṅga</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn.</span> the interior part or seat of a carriage; having an interior part or seat; ?</p></dd><dt><dfn>nelaṅga</dfn><sup>2</sup></dt><dd><p><span class='case'>neuter & mfn.</span> (see <i><a href='/define/nela'>nela</a></i>)</p></dd></dl>"
+        "text": "<dl id='nelaṅga'><dt><dfn>nelaṅga</dfn><sup>1</sup></dt><dd><p><span class='case'>mfn.</span> whose parts are faultless; whose frame is smooth or polished; ? (see <i><a href='/define/nela'>nela</a></i>)</p></dd><dt><dfn>nelaṅga</dfn><sup>2</sup></dt><dd><p><span class='case'>mfn.</span> the interior part or seat of a carriage; having an interior part or seat; ?</p></dd></dl>"
     },
     {
         "word": "neḷa",
-        "text": "<dl id='neḷa'><dt><dfn>neḷa</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ñeyya'>ñeyya</a></i>)</p></dd></dl>"
+        "text": "<dl id='neḷa'><dt><dfn>neḷa</dfn></dt><dd><p><span class='case'>neuter & mfn.</span> (see <i><a href='/define/nela'>nela</a></i>)</p></dd></dl>"
     },
     {
         "word": "nevasaññanāsañña",
-        "text": "<dl id='nevasaññanāsañña'><dt><dfn>nevasaññanāsañña</dfn></dt><dd><p><span class='case'>mfn. & ~ā, f</span></p><ol type='1' class='decimal'><li>the sphere or stage of neither apperception nor non-apperception, i.e.</li><li>the fourth of the arūpa states of existence; and.</li><li>the fourth arūpajhana or one of the vimokkhas.</li></ol></dd></dl>"
+        "text": "<dl id='nevasaññanāsañña'><dt><dfn>nevasaññanāsañña</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/ñeyya'>ñeyya</a></i>)</p></dd></dl>"
     },
     {
         "word": "nevasaññanāsaññāyatana",
-        "text": "<dl id='nevasaññanāsaññāyatana'><dt><dfn>nevasaññanāsaññāyatana</dfn></dt><dd><p><span class='case'>neuter</span> (cpd from n’eva saññi nasaññi), possessing neither apperception nor nonapperception.</p></dd></dl>"
-    },
-    {
-        "word": "nevasaññīnāsaññīn",
-        "text": "<dl id='nevasaññīnāsaññīn'><dt><dfn>nevasaññīnāsaññī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> one who throws down, who scatters.</p></dd></dl>"
+        "text": "<dl id='nevasaññanāsaññāyatana'><dt><dfn>nevasaññanāsaññāyatana</dfn></dt><dd><p><span class='case'>mfn. & ~ā, f</span></p><ol type='1' class='decimal'><li>the sphere or stage of neither apperception nor non-apperception, i.e.</li><li>the fourth of the arūpa states of existence; and.</li><li>the fourth arūpajhana or one of the vimokkhas.</li></ol></dd></dl>"
     },
     {
         "word": "nevasaññīnāsaññī",
-        "text": "<dl id='nevasaññīnāsaññī'><dt><dfn>nevasaññīnāsaññī(n)</dfn></dt><dd><p><span class='case'>mfn.</span> one who throws down, who scatters.</p></dd></dl>"
+        "text": "<dl id='nevasaññīnāsaññīn'><dt><dfn>nevasaññīnāsaññī(n)</dfn></dt><dd><p><span class='case'>neuter</span> (cpd from n’eva saññi nasaññi), possessing neither apperception nor nonapperception.</p></dd></dl>"
+    },
+    {
+        "word": "nevasaññīnāsaññīn",
+        "text": "<dl id='nevasaññīnāsaññīn'><dt><dfn>nevasaññīnāsaññī(n)</dfn></dt><dd><p><span class='case'>neuter</span> (cpd from n’eva saññi nasaññi), possessing neither apperception nor nonapperception.</p></dd></dl>"
     },
     {
         "word": "nevāpika",
-        "text": "<dl id='nevāpika'><dt><dfn>nevāpika</dfn></dt><dd><p><span class='case'>masculine</span> resident, in (present or long-term) residence; a resident; a resident.</p></dd></dl>"
+        "text": "<dl id='nevāpika'><dt><dfn>nevāpika</dfn></dt><dd><p><span class='case'>mfn.</span> one who throws down, who scatters.</p></dd></dl>"
     },
     {
         "word": "nevāsika",
-        "text": "<dl id='nevāsika'><dt><dfn>nevāsika</dfn></dt><dd><p><span class='case'>m.a of na</span> (see <i><a href='/define/na'>na</a></i>)</p></dd></dl>"
+        "text": "<dl id='nevāsika'><dt><dfn>nevāsika</dfn></dt><dd><p><span class='case'>masculine</span> resident, in (present or long-term) residence; a resident; a resident.</p></dd></dl>"
     },
     {
         "word": "nesaṃ",
-        "text": "<dl id='nesaṃ'><dt><dfn>nesaṃ</dfn></dt><dd><p><span class='case'>gen./dat.</span> (an ascetic) who does not use a bed; (an ascetic or bhikkhu) who rests or sleeps only in a sitting position; requiring sitting only (not lying); a <i>bhikkhu</i> who has undertaken the dhutanga of not lying down.</p></dd></dl>"
+        "text": "<dl id='nesaṃ'><dt><dfn>nesaṃ</dfn></dt><dd><p><span class='case'>m.a of na</span> (see <i><a href='/define/na'>na</a></i>)</p></dd></dl>"
     },
     {
         "word": "nesajjika",
-        "text": "<dl id='nesajjika'><dt><dfn>nesajjika</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> a man of a particular low caste (of hunters); a fowler, a hunter.</p></dd></dl>"
+        "text": "<dl id='nesajjika'><dt><dfn>nesajjika</dfn></dt><dd><p><span class='case'>gen./dat.</span> (an ascetic) who does not use a bed; (an ascetic or bhikkhu) who rests or sleeps only in a sitting position; requiring sitting only (not lying); a <i>bhikkhu</i> who has undertaken the dhutanga of not lying down.</p></dd></dl>"
     },
     {
         "word": "nesāda",
-        "text": "<dl id='nesāda'><dt><dfn>nesāda</dfn></dt><dd><p><span class='case'>masculine</span> a woman of a particular low caste (of hunters); a fowler, a huntress.</p></dd></dl>"
+        "text": "<dl id='nesāda'><dt><dfn>nesāda</dfn></dt><dd><p><span class='case'>mfn. & masculine</span> a man of a particular low caste (of hunters); a fowler, a hunter.</p></dd></dl>"
     },
     {
         "word": "nesādī",
-        "text": "<dl id='nesādī'><dt><dfn>nesādī</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nesādī'><dt><dfn>nesādī</dfn></dt><dd><p><span class='case'>masculine</span> a woman of a particular low caste (of hunters); a fowler, a huntress.</p></dd></dl>"
     },
     {
         "word": "nesuṃ",
-        "text": "<dl id='nesuṃ'><dt><dfn>nesuṃ</dfn></dt><dd><p><span class='case'>3 pl.</span> us, me.</p></dd></dl>"
+        "text": "<dl id='nesuṃ'><dt><dfn>nesuṃ</dfn></dt><dd><p><span class='case'>feminine</span> (see <i><a href='/define/nayati'>nayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "no",
-        "text": "<dl id='no'><dt><dfn>no</dfn><sup>1</sup></dt><dd><p><span class='case'>pl.</span> of us; to us; by us.</p></dd><dt><dfn>no</dfn><sup>2</sup></dt><dd><p><span class='case'>pl.</span></p><ol type='1' class='decimal'><li>not; esp.:</li><li>and not, but not (often followed by ca or ca kho)</li><li>nor.</li><li>or not (either alone or with vā, udāhu etc)</li><li>no ce:<ol type='i' class='lower-roman'><li>if not (followed by a verb, or forming a sentence by itself)</li><li>may there not; I hope that … not.</li></ol></li><li>no! not so.</li></ol></dd><dt><dfn>no</dfn><sup>3</sup></dt><dd><p><span class='case'>indeclinable</span> emphatic and interrog. particle.</p></dd><dt><dfn>no</dfn><sup>4</sup></dt><dd><p><span class='case'>ind.</span> (see <i><a href='/define/navanīta'>navanīta</a></i>)</p></dd></dl>"
+        "text": "<dl id='no'><dt><dfn>no</dfn><sup>1</sup></dt><dd><p><span class='case'>3 pl.</span> us, me.</p></dd><dt><dfn>no</dfn><sup>2</sup></dt><dd><p><span class='case'>pl.</span> of us; to us; by us.</p></dd><dt><dfn>no</dfn><sup>3</sup></dt><dd><p><span class='case'>pl.</span></p><ol type='1' class='decimal'><li>not; esp.:</li><li>and not, but not (often followed by ca or ca kho)</li><li>nor.</li><li>or not (either alone or with vā, udāhu etc)</li><li>no ce:<ol type='i' class='lower-roman'><li>if not (followed by a verb, or forming a sentence by itself)</li><li>may there not; I hope that … not.</li></ol></li><li>no! not so.</li></ol></dd><dt><dfn>no</dfn><sup>4</sup></dt><dd><p><span class='case'>indeclinable</span> emphatic and interrog. particle.</p></dd></dl>"
     },
     {
         "word": "nonīta",
-        "text": "<dl id='nonīta'><dt><dfn>nonīta</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nonīta'><dt><dfn>nonīta</dfn></dt><dd><p><span class='case'>ind.</span> (see <i><a href='/define/navanīta'>navanīta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhatvā",
-        "text": "<dl id='nhatvā'><dt><dfn>nhatvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nahāta'>nahāta</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhatvā'><dt><dfn>nhatvā</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāta",
-        "text": "<dl id='nhāta'><dt data-main-entry='nahāyati'><dfn>nhāta</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nahātaka'>nahātaka</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāta'><dt data-main-entry='nahāyati'><dfn>nhāta</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nahāta'>nahāta</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhātaka",
-        "text": "<dl id='nhātaka'><dt><dfn>nhātaka</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhātaka'><dt><dfn>nhātaka</dfn></dt><dd><p><span class='case'>pp mfn.</span> (see <i><a href='/define/nahātaka'>nahātaka</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhātvā",
-        "text": "<dl id='nhātvā'><dt><dfn>nhātvā</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nahāna'>nahāna</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhātvā'><dt><dfn>nhātvā</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāna",
-        "text": "<dl id='nhāna'><dt><dfn>nhāna</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāniya'>nahāniya</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāna'><dt><dfn>nhāna</dfn></dt><dd><p><span class='case'>absol.</span> (see <i><a href='/define/nahāna'>nahāna</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhānīya",
-        "text": "<dl id='nhānīya'><dt><dfn>nhānīya</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nahāpaka'>nahāpaka</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhānīya'><dt><dfn>nhānīya</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāniya'>nahāniya</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpaka",
-        "text": "<dl id='nhāpaka'><dt><dfn>nhāpaka</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāpana'>nahāpana</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpaka'><dt><dfn>nhāpaka</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nahāpaka'>nahāpaka</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpana",
-        "text": "<dl id='nhāpana'><dt><dfn>nhāpana</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāpayati'>nahāpayati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpana'><dt><dfn>nhāpana</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāpana'>nahāpana</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpayati",
-        "text": "<dl id='nhāpayati'><dt><dfn>nhāpayati</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nahāpita'>nahāpita</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpayati'><dt><dfn>nhāpayati</dfn></dt><dd><p><span class='case'>neuter</span> (see <i><a href='/define/nahāpayati'>nahāpayati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpita",
-        "text": "<dl id='nhāpita'><dt><dfn>nhāpita</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpita'><dt><dfn>nhāpita</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nahāpita'>nahāpita</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpetabba",
-        "text": "<dl id='nhāpetabba'><dt><dfn>nhāpetabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpetabba'><dt><dfn>nhāpetabba</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpeti",
-        "text": "<dl id='nhāpeti'><dt><dfn>nhāpeti</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nahāpetvā'>nahāpetvā</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpeti'><dt><dfn>nhāpeti</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpetvā",
-        "text": "<dl id='nhāpetvā'><dt><dfn>nhāpetvā</dfn></dt><dd><p><span class='case'>absol. of nahāpeti</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpetvā'><dt><dfn>nhāpetvā</dfn></dt><dd><p><span class='case'>caus. pr. 3 sg.</span> (see <i><a href='/define/nahāpetvā'>nahāpetvā</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāpesuṃ",
-        "text": "<dl id='nhāpesuṃ'><dt><dfn>nhāpesuṃ</dfn></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/nahāru'>nahāru</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāpesuṃ'><dt><dfn>nhāpesuṃ</dfn></dt><dd><p><span class='case'>absol. of nahāpeti</span> (see <i><a href='/define/nahāpeti'>nahāpeti</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāru",
-        "text": "<dl id='nhāru'><dt><dfn>nhāru</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nahārudaddula'>nahārudaddula</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāru'><dt><dfn>nhāru</dfn></dt><dd><p><span class='case'>3 pl.</span> (see <i><a href='/define/nahāru'>nahāru</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhārudaddula",
-        "text": "<dl id='nhārudaddula'><dt><dfn>nhārudaddula</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhārudaddula'><dt><dfn>nhārudaddula</dfn></dt><dd><p><span class='case'>mfn.</span> (see <i><a href='/define/nahārudaddula'>nahārudaddula</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyati",
-        "text": "<dl id='nhāyati'><dt><dfn>nhāyati</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyati'><dt><dfn>nhāyati</dfn></dt><dd><p><span class='case'>masculine</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyanta",
-        "text": "<dl id='nhāyanta'><dt><dfn>nhāyanta</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyanta'><dt><dfn>nhāyanta</dfn></dt><dd><p><span class='case'>pr. 3 sg. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyamāna",
-        "text": "<dl id='nhāyamāna'><dt><dfn>nhāyamāna</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyamāna'><dt><dfn>nhāyamāna</dfn></dt><dd><p><span class='case'>part. pr. mf(~antī)n. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyiṃsu",
-        "text": "<dl id='nhāyiṃsu'><dt><dfn>nhāyiṃsu</dfn></dt><dd><p><span class='case'>3 pl. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyiṃsu'><dt><dfn>nhāyiṃsu</dfn></dt><dd><p><span class='case'>part. pr. mfn. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyitabba",
-        "text": "<dl id='nhāyitabba'><dt><dfn>nhāyitabba</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyitabba'><dt><dfn>nhāyitabba</dfn></dt><dd><p><span class='case'>3 pl. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyituṃ",
-        "text": "<dl id='nhāyituṃ'><dt><dfn>nhāyituṃ</dfn></dt><dd><p><span class='case'>inf. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyituṃ'><dt><dfn>nhāyituṃ</dfn></dt><dd><p><span class='case'>fpp mfn.</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     },
     {
         "word": "nhāyitvā",
-        "text": "<dl id='nhāyitvā'><dt><dfn>nhāyitvā</dfn></dt><dd><p><span class='case'>absol. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
+        "text": "<dl id='nhāyitvā'><dt><dfn>nhāyitvā</dfn></dt><dd><p><span class='case'>inf. of nahāyati</span> (see <i><a href='/define/nahāyati'>nahāyati</a></i>)</p></dd></dl>"
     }
 ]


### PR DESCRIPTION
This is a slightly a hatchet fix (it got a tad messier than hoped) so in the, fingers-crossed unlikely, event that it needs to be revisited, I'm adding some background detail:

Off-by-1definition errors starting from ln. 51207 (niṭṭhā) originate from the spreadsheet given in the OP of the [Implementing the New Concise Pali English Dictionary](https://discourse.suttacentral.net/t/implementing-the-new-concise-pali-english-dictionary/3413) thread from Oct 2016.

The entry for niṭṭhā at ln. 4050 included the content of the following entry (niṭṭhaṁ gacchati). All entries thereafter were off by one. A corrected spreadsheet is available here, [ncped_fixed.zip](https://github.com/suttacentral/sc-data/files/3665950/ncped_fixed.zip), however, naturally, the fix pushed in this branch is the result of working directly with the corresponding json file produced subsequently from the html file (produced from the original spreadsheet). The html and json files were subject to several updates since autumn 2016, and these have been preserved. 

If niggly errors _do_ persist (I've done many spot checks and all seems to be in order, but, y'know… :woman_shrugging: ) it's probably best to completely ditch the work in this branch and start again from commit be4216dea36 armed with the info here offered).
