### PR TITLE
Remove footnote

### DIFF
--- a/html_text/de/pli/sutta/sn/sn4/sn4.19.html
+++ b/html_text/de/pli/sutta/sn/sn4/sn4.19.html
@@ -36,7 +36,6 @@ und die es sagen: zu denen gehöre ich nicht.<br>
 So wisse denn, du Böser, nicht einmal meinen Pfad wirst du sehen.“</p>
 </blockquote>
 <p><a class='ref sc' id='sc14' href='#sc14'>SC 14</a> Da merkte Māra, der Böse: es kennt mich der Erhabene, es kennt mich der Führer auf dem Heilspfad, und verschwand auf der Stelle leidvoll und betrübt.</p>
-<p><a class='ref sc' id='sc15' href='#sc15'>SC 15</a> Wovon die Leute sagen: mein ist das—von dem sage ich: das ist nicht mein. Der Sinn ist also: die empirischen Dinge an denen die Leute hängen berühren mich nicht; mein Denken hat den Kontakt mit der empirischen Welt aufgegeben.</p>
 <footer>
 <p>Übersetzer: <span class='author'>Wilhelm Geiger</span>, <cite class='book' translate='no'>Die Reden des Buddha Gruppierte Sammlung</cite>.</p>
 <p><span class='publication-date'>1925</span> erstmaliges Erscheinen des <span class='roman-numerals'>II</span>. Buches, erster Teil (Saṁyutta 12–16). <span class='publication-date'>1930</span> erstmaliges Erscheinen des <span class='roman-numerals'>I</span>. Buches (Saṁyutta 1–11).</p>


### PR DESCRIPTION
Line 39 (id=sc15) is not part of the text, but is a note by the translator. I can clearly see it in the printed version, it's a footnote. We don't usually show such notes, so it should probably be deleted. If that is the right thing to do, please merge this pull request, otherwise just close it.