### PR TITLE
fix extra dots in NCPED

### DIFF
--- a/dictionaries/simple/en/pli2en_ncped.json
+++ b/dictionaries/simple/en/pli2en_ncped.json
@@ -2204,7 +2204,7 @@
   {
     "entry": "accāyata",
     "grammar": "adjective",
-    "definition": "very much stretc.hed or extended; over-strung (opposite to atisithila); high, sharp",
+    "definition": "very much stretched or extended; over-strung (opposite to atisithila); high, sharp",
     "xr": "ati+āyati"
   },
   {
@@ -3257,7 +3257,7 @@
   {
     "entry": "añchati",
     "grammar": "present 3 singular",
-    "definition": "stretc.hes; pulls, drags, turns (on a lathe)"
+    "definition": "stretches; pulls, drags, turns (on a lathe)"
   },
   {
     "entry": "añjati",
@@ -17691,7 +17691,7 @@
   {
     "entry": "abhininnāmeti",
     "grammar": "present 3 singular",
-    "definition": "bends; stretc.hes out; directs (towards, dative/genitive)"
+    "definition": "bends; stretches out; directs (towards, dative/genitive)"
   },
   {
     "entry": "abhininnāmesi",
@@ -18168,13 +18168,13 @@
   {
     "entry": "abhinīharati",
     "grammar": "present 3 singular",
-    "definition": "draws out; stretc.hes out (towards); moves (thought) out",
+    "definition": "draws out; stretches out (towards); moves (thought) out",
     "xr": "abhinīharati"
   },
   {
     "entry": "abhinīhāra",
     "grammar": "masculine",
-    "definition": "stretc.hing out, moving (towards); intended action, firm intention; scheme"
+    "definition": "stretching out, moving (towards); intended action, firm intention; scheme"
   },
   {
     "entry": "abhinetabba",
@@ -18323,7 +18323,7 @@
   {
     "entry": "abhippasāreti",
     "grammar": "present 3 singular",
-    "definition": "stretc.hes out towards",
+    "definition": "stretches out towards",
     "xr": "abhippasīdati"
   },
   {
@@ -19630,7 +19630,7 @@
     "entry": "abhiharati",
     "grammar": "present 3 singular",
     "definition": [
-      "fetc.hes, brings; offers; brings forward, advances; brings near, fetc.hes for oneself, partakes of",
+      "fetches, brings; offers; brings forward, advances; brings near, fetches for oneself, partakes of",
       "(counter-)attacks"
     ]
   },
@@ -23458,7 +23458,7 @@
   {
     "entry": "ātura",
     "grammar": "adjective",
-    "definition": "sick, ill; suffering, afflicted; wretc.hed"
+    "definition": "sick, ill; suffering, afflicted; wretched"
   },
   {
     "entry": "āturīyati",
@@ -23800,7 +23800,7 @@
   {
     "entry": "ādīnava",
     "grammar": "masculine",
-    "definition": "wretc.hedness; bad consequence, disadvantage, danger (in, locative or genitive)"
+    "definition": "wretchedness; bad consequence, disadvantage, danger (in, locative or genitive)"
   },
   {
     "entry": "ādīnavadassa",
@@ -24032,7 +24032,7 @@
   {
     "entry": "ānayati",
     "grammar": "present 3 singular",
-    "definition": "leads towards or near; brings, fetc.hes; brings home, brings home (as a wife); brings back; supplies, understands (a meaning or word)",
+    "definition": "leads towards or near; brings, fetches; brings home, brings home (as a wife); brings back; supplies, understands (a meaning or word)",
     "xr": "āneti"
   },
   {
@@ -24043,13 +24043,13 @@
   {
     "entry": "ānāpayati",
     "grammar": "causative present 3 singular",
-    "definition": "(see also ānāpeti) causes to be brought; has fetc.hed",
+    "definition": "(see also ānāpeti) causes to be brought; has fetched",
     "xr": "āneti"
   },
   {
     "entry": "ānāpeti",
     "grammar": "causative present 3 singular",
-    "definition": "(see also ānāpayati) (sometimes confused with, and written as, āṇāpeti), causes to be brought; has fetc.hed",
+    "definition": "(see also ānāpayati) (sometimes confused with, and written as, āṇāpeti), causes to be brought; has fetched",
     "xr": "āneti"
   },
   {
@@ -24075,7 +24075,7 @@
   {
     "entry": "ānīta",
     "grammar": "past participle adjective",
-    "definition": "led near; brought; fetc.hed, brought home",
+    "definition": "led near; brought; fetched, brought home",
     "xr": "āneti"
   },
   {
@@ -24178,7 +24178,7 @@
   {
     "entry": "āneti",
     "grammar": "present 3 singular",
-    "definition": "leads towards or near; brings, fetc.hes; brings home, brings home (as a wife); brings back; supplies, understands (a meaning or word)",
+    "definition": "leads towards or near; brings, fetches; brings home, brings home (as a wife); brings back; supplies, understands (a meaning or word)",
     "xr": "ānayati"
   },
   {
@@ -25021,7 +25021,7 @@
   {
     "entry": "āyata",
     "grammar": "past participle adjective",
-    "definition": "stretc.hed, stretc.hed out; extended, long; long-drawn-out",
+    "definition": "stretched, stretched out; extended, long; long-drawn-out",
     "xr": "āyamati"
   },
   {
@@ -25102,7 +25102,7 @@
   {
     "entry": "āyamati",
     "grammar": "present 3 singular",
-    "definition": "stretc.hes, stretc.hes out (trans. and intrans.); expands"
+    "definition": "stretches, stretches out (trans. and intrans.); expands"
   },
   {
     "entry": "āyamukha",
@@ -27564,7 +27564,7 @@
     "entry": "āharati",
     "grammar": "present 3 singular",
     "definition": [
-      "brings, fetc.hes, conveys; takes, collects; uses",
+      "brings, fetches, conveys; takes, collects; uses",
       "satthaṁ ~ati, ~eti, takes the knife, kills oneself"
     ],
     "xr": "āhareti"
@@ -27582,7 +27582,7 @@
   {
     "entry": "āharāpayati",
     "grammar": "causative present 3 singular",
-    "definition": "causes to be taken or fetc.hed; sends for; demands",
+    "definition": "causes to be taken or fetched; sends for; demands",
     "xr": [
       "āharāpeti",
       "āharati"
@@ -27591,7 +27591,7 @@
   {
     "entry": "āharāpeti",
     "grammar": "causative present 3 singular",
-    "definition": "causes to be taken or fetc.hed; sends for; demands",
+    "definition": "causes to be taken or fetched; sends for; demands",
     "xr": [
       "āharāpayati",
       "āharati"
@@ -27694,7 +27694,7 @@
     "entry": "āhareti",
     "grammar": "present 3 singular",
     "definition": [
-      "brings, fetc.hes, conveys; takes, collects; uses",
+      "brings, fetches, conveys; takes, collects; uses",
       "satthaṁ ~ati, ~eti, takes the knife, kills oneself"
     ],
     "xr": "āharati"
@@ -31138,7 +31138,7 @@
   {
     "entry": "udakahāra",
     "grammar": "mf(~ī)",
-    "definition": "(one) who fetc.hes or carries water; fetc.hing water",
+    "definition": "(one) who fetches or carries water; fetching water",
     "xr": "udaka"
   },
   {
@@ -32278,7 +32278,7 @@
   {
     "entry": "upakappeti",
     "grammar": "causative present 3 singular",
-    "definition": "prepares, makes ready; brings near, fetc.hes",
+    "definition": "prepares, makes ready; brings near, fetches",
     "xr": "upakappati"
   },
   {
@@ -32762,7 +32762,7 @@
   {
     "entry": "upaṭṭhapayati",
     "grammar": "causative present 3 singular",
-    "definition": "(also upaṭṭhāpeti, upaṭṭhapeti) brings near, provides; procures, fetc.hes; makes serve or attend, employs; causes to appear, brings about",
+    "definition": "(also upaṭṭhāpeti, upaṭṭhapeti) brings near, provides; procures, fetches; makes serve or attend, employs; causes to appear, brings about",
     "xr": [
       "upaṭṭhahati",
       "upaṭṭheti"
@@ -32771,7 +32771,7 @@
   {
     "entry": "upaṭṭhapeti",
     "grammar": "causative present 3 singular",
-    "definition": "(also upaṭṭhāpeti, upaṭṭhapayati) brings near, provides; procures, fetc.hes; makes serve or attend, employs; causes to appear, brings about",
+    "definition": "(also upaṭṭhāpeti, upaṭṭhapayati) brings near, provides; procures, fetches; makes serve or attend, employs; causes to appear, brings about",
     "xr": [
       "upaṭṭhahati",
       "upaṭṭheti"
@@ -32866,7 +32866,7 @@
   {
     "entry": "upaṭṭhāpayati",
     "grammar": "causative present 3 singular",
-    "definition": "brings near, provides; procures, fetc.hes; makes serve or attend, employs; causes to appear, brings about",
+    "definition": "brings near, provides; procures, fetches; makes serve or attend, employs; causes to appear, brings about",
     "xr": [
       "upaṭṭhapeti",
       "upaṭṭhāpeti, upaṭṭheti"
@@ -32908,7 +32908,7 @@
   {
     "entry": "upaṭṭhāpeti",
     "grammar": "causative present 3 singular",
-    "definition": "(also upaṭṭhapeti, upaṭṭhapayati) brings near, provides; procures, fetc.hes; makes serve or attend, employs; causes to appear, brings about",
+    "definition": "(also upaṭṭhapeti, upaṭṭhapayati) brings near, provides; procures, fetches; makes serve or attend, employs; causes to appear, brings about",
     "xr": [
       "upaṭṭhahati",
       "upaṭṭheti"
@@ -36320,7 +36320,7 @@
     "grammar": "masculine",
     "definition": [
       "an awning; a ceiling of cloth",
-      "a cloth stretc.hed over a bedstead (below the mattress)"
+      "a cloth stretched over a bedstead (below the mattress)"
     ]
   },
   {
@@ -36456,7 +36456,7 @@
   {
     "entry": "usukāra",
     "grammar": "masculine",
-    "definition": "arrow maker, a fletc.her",
+    "definition": "arrow maker, a fletcher",
     "xr": "usu"
   },
   {
@@ -39706,7 +39706,7 @@
   {
     "entry": "otārayati",
     "grammar": "present 3 singular",
-    "definition": "causes to descend, makes go down (into), fetc.hes down; lets down, lowers, puts down; takes down, removes; makes appear, puts forward; makes alight",
+    "definition": "causes to descend, makes go down (into), fetches down; lets down, lowers, puts down; takes down, removes; makes appear, puts forward; makes alight",
     "xr": [
       "otāreti",
       "otarati"
@@ -39737,7 +39737,7 @@
   {
     "entry": "otāreti",
     "grammar": "present 3 singular",
-    "definition": "causes to descend, makes go down (into), fetc.hes down; lets down, lowers, puts down; takes down, removes; makes appear, puts forward; makes alight",
+    "definition": "causes to descend, makes go down (into), fetches down; lets down, lowers, puts down; takes down, removes; makes appear, puts forward; makes alight",
     "xr": [
       "otārayati",
       "otarati"
@@ -40088,13 +40088,13 @@
   {
     "entry": "onaddha",
     "grammar": "past participle adjective",
-    "definition": "covered; having something stretc.hed over",
+    "definition": "covered; having something stretched over",
     "xr": "onandhati"
   },
   {
     "entry": "onandhati",
     "grammar": "present 3 singular",
-    "definition": "covers; stretc.hes over (transitive)",
+    "definition": "covers; stretches over (transitive)",
     "xr": [
       "onayhati",
       "onahati"
@@ -40120,7 +40120,7 @@
   {
     "entry": "onayhati",
     "grammar": "present 3 singular",
-    "definition": "covers; stretc.hes over (transitive)",
+    "definition": "covers; stretches over (transitive)",
     "xr": [
       "onandhati",
       "onahati"
@@ -40129,7 +40129,7 @@
   {
     "entry": "onahati",
     "grammar": "present 3 singular",
-    "definition": "covers; stretc.hes over (transitive)",
+    "definition": "covers; stretches over (transitive)",
     "xr": [
       "onandhati",
       "onayhati"
@@ -43589,12 +43589,12 @@
   {
     "entry": "kapaṇa",
     "grammar": "adjective (f. ~ā & ~ī)& masculine",
-    "definition": "pitiable, pitiful; wretc.hed; poor, mean; a poor man, a wretc.h"
+    "definition": "pitiable, pitiful; wretched; poor, mean; a poor man, a wretch"
   },
   {
     "entry": "kapaṇikā",
     "grammar": "adjective (feminine)",
-    "definition": "pitiful, wretc.hed"
+    "definition": "pitiful, wretched"
   },
   {
     "entry": "kapalla",
@@ -48490,7 +48490,7 @@
   {
     "entry": "kumbhadāsika",
     "grammar": "feminine",
-    "definition": "the slave girl who fetc.hes water, a scullery-maid; a prostitute",
+    "definition": "the slave girl who fetches water, a scullery-maid; a prostitute",
     "xr": [
       "kumbha",
       "kumbhadāsī"
@@ -48499,7 +48499,7 @@
   {
     "entry": "kumbhadāsī",
     "grammar": "feminine",
-    "definition": "the slave girl who fetc.hes water, a scullery-maid; a prostitute",
+    "definition": "the slave girl who fetches water, a scullery-maid; a prostitute",
     "xr": [
       "kumbha",
       "kumbhadāsikā"
@@ -54634,7 +54634,7 @@
   {
     "entry": "ghāsahāraka",
     "grammar": "m(fn.)",
-    "definition": "(one) who fetc.hes or carries fodder"
+    "definition": "(one) who fetches or carries fodder"
   },
   {
     "entry": "ghurughurupassāsi(n)",
@@ -57866,7 +57866,7 @@
     "grammar": "masculine/feminine& adjective",
     "definition": [
       "(m. feminine) a corpse; a dead body",
-      "(adjective) vile; base; wretc.hed; inferior; paltry"
+      "(adjective) vile; base; wretched; inferior; paltry"
     ]
   },
   {
@@ -58969,7 +58969,7 @@
   {
     "entry": "jamma",
     "grammar": "adjective (f. ~ī)",
-    "definition": "contemptible, low; of low birth; a contemptible person, a wretc.h"
+    "definition": "contemptible, low; of low birth; a contemptible person, a wretch"
   },
   {
     "entry": "jammana",
@@ -59040,7 +59040,7 @@
   {
     "entry": "jarasigāla",
     "grammar": "masculine",
-    "definition": "an old jackal; a wretc.hed jackal"
+    "definition": "an old jackal; a wretched jackal"
   },
   {
     "entry": "jarasiṅgala",
@@ -62915,12 +62915,12 @@
   {
     "entry": "tiṇahāraka",
     "grammar": "masculine",
-    "definition": "one who fetc.hes (cuts and sells) grass or hay"
+    "definition": "one who fetches (cuts and sells) grass or hay"
   },
   {
     "entry": "tiṇahāri",
     "grammar": "feminine",
-    "definition": "(one) who fetc.hes grass or hay"
+    "definition": "(one) who fetches grass or hay"
   },
   {
     "entry": "tiṇukkā",
@@ -67216,22 +67216,22 @@
   {
     "entry": "duggata",
     "grammar": "adjective",
-    "definition": "having a wretc.hed (re) -birth; poor, unfortunate, ill-fated"
+    "definition": "having a wretched (re) -birth; poor, unfortunate, ill-fated"
   },
   {
     "entry": "duggati",
     "grammar": "feminine",
-    "definition": "a wretc.hed (re) -birth or state of existence; an ill destiny; misfortune, poverty"
+    "definition": "a wretched (re) -birth or state of existence; an ill destiny; misfortune, poverty"
   },
   {
     "entry": "duggatigamana",
     "grammar": "adjective & neuter",
-    "definition": "going to a wretc.hed existence"
+    "definition": "going to a wretched existence"
   },
   {
     "entry": "duggatigāmin(n)",
     "grammar": "adjective",
-    "definition": "leading to a wretc.hed existence"
+    "definition": "leading to a wretched existence"
   },
   {
     "entry": "duggaha",
@@ -72929,7 +72929,7 @@
   {
     "entry": "nigrodhaparimaṇḍala",
     "grammar": "adjective",
-    "definition": "circular as a banyan (one whose body and outstretc.hed arms make a circle like a banyan); perfectly proportioned"
+    "definition": "circular as a banyan (one whose body and outstretched arms make a circle like a banyan); perfectly proportioned"
   },
   {
     "entry": "nigha",
@@ -77540,24 +77540,24 @@
   {
     "entry": "paggaṇhanta",
     "grammar": "present participle",
-    "definition": "holding up; taking up; supporting; favoring; stretc.hing forth",
+    "definition": "holding up; taking up; supporting; favoring; stretching forth",
     "xr": "paggaṇhāti"
   },
   {
     "entry": "paggaṇhāti",
     "grammar": "pa + gah + ṇhā",
-    "definition": "holds up; takes up; supports; favors; stretc.hes forth"
+    "definition": "holds up; takes up; supports; favors; stretches forth"
   },
   {
     "entry": "paggaṇhi",
     "grammar": "aorist",
-    "definition": "held up; took up; supported; favored; stretc.hed forth",
+    "definition": "held up; took up; supported; favored; stretched forth",
     "xr": "paggaṇhāti"
   },
   {
     "entry": "paggayha",
     "grammar": "absolutive",
-    "definition": "having held up; having taken up; having supported; having favored; having stretc.hed forth",
+    "definition": "having held up; having taken up; having supported; having favored; having stretched forth",
     "xr": "paggaṇhāti"
   },
   {
@@ -77573,7 +77573,7 @@
   {
     "entry": "paggahita",
     "grammar": "past participle",
-    "definition": "held up; stretc.h out",
+    "definition": "held up; stretch out",
     "xr": "paggaṇhāti"
   },
   {
@@ -77585,7 +77585,7 @@
   {
     "entry": "paggahetvā",
     "grammar": "absolutive",
-    "definition": "having held up; having taken up; having supported; having favored; having stretc.hed forth",
+    "definition": "having held up; having taken up; having supported; having favored; having stretched forth",
     "xr": "paggaṇhāti"
   },
   {
@@ -81502,30 +81502,30 @@
   {
     "entry": "paṇāmita",
     "grammar": "past participle",
-    "definition": "dismissed; ejected; shut; stretc.hed out",
+    "definition": "dismissed; ejected; shut; stretched out",
     "xr": "paṇāmeti"
   },
   {
     "entry": "paṇāmeti",
     "grammar": "pa + nam + e",
-    "definition": "dismisses; ejects; shuts; stretc.hes out"
+    "definition": "dismisses; ejects; shuts; stretches out"
   },
   {
     "entry": "paṇāmetvā",
     "grammar": "absolutive",
-    "definition": "having dismissed; having ejected; having shut; having stretc.hed out",
+    "definition": "having dismissed; having ejected; having shut; having stretched out",
     "xr": "paṇāmeti"
   },
   {
     "entry": "paṇāmenta",
     "grammar": "present participle",
-    "definition": "dismissing; ejecting; shutting; stretc.hing out",
+    "definition": "dismissing; ejecting; shutting; stretching out",
     "xr": "paṇāmeti"
   },
   {
     "entry": "paṇāmesi",
     "grammar": "aorist",
-    "definition": "dismissed; ejected; shut; stretc.hed out",
+    "definition": "dismissed; ejected; shut; stretched out",
     "xr": "paṇāmeti"
   },
   {
@@ -88746,29 +88746,29 @@
   {
     "entry": "pasāraṇa",
     "grammar": "neuter",
-    "definition": "stretc.hing out; spreading"
+    "definition": "stretching out; spreading"
   },
   {
     "entry": "pasārita",
     "grammar": "past participle",
-    "definition": "stretc.hed out",
+    "definition": "stretched out",
     "xr": "pasāreti"
   },
   {
     "entry": "pasāreti",
     "grammar": "pa + sar + e",
-    "definition": "stretc.hes out; spreads; holds out; offers for sale"
+    "definition": "stretches out; spreads; holds out; offers for sale"
   },
   {
     "entry": "pasāretvā",
     "grammar": "absolutive",
-    "definition": "having stretc.hed out; having spread; having held out; having offered for sale",
+    "definition": "having stretched out; having spread; having held out; having offered for sale",
     "xr": "pasāreti"
   },
   {
     "entry": "pasāresi",
     "grammar": "aorist",
-    "definition": "stretc.hed out; spread; held out; offered for sale",
+    "definition": "stretched out; spread; held out; offered for sale",
     "xr": "pasāreti"
   },
   {
@@ -92918,7 +92918,7 @@
   {
     "entry": "porisa",
     "grammar": "neuter",
-    "definition": "manliness; the height of man (with up stretc.hed hand)"
+    "definition": "manliness; the height of man (with up stretched hand)"
   },
   {
     "entry": "porisāda",
@@ -108307,7 +108307,7 @@
   {
     "entry": "varāka",
     "grammar": "adjective",
-    "definition": "wretc.hed; a miserable person"
+    "definition": "wretched; a miserable person"
   },
   {
     "entry": "varārohā",
@@ -111464,7 +111464,7 @@
   {
     "entry": "vitata",
     "grammar": "past participle",
-    "definition": "stretc.hed; extended; diffused",
+    "definition": "stretched; extended; diffused",
     "xr": "vitanoti"
   },
   {
@@ -111475,13 +111475,13 @@
   {
     "entry": "vitani",
     "grammar": "aorist",
-    "definition": "stretc.hed or spread out",
+    "definition": "stretched or spread out",
     "xr": "vitanoti"
   },
   {
     "entry": "vitanoti",
     "grammar": "vi + tan + o",
-    "definition": "stretc.hes or spreads out"
+    "definition": "stretches or spreads out"
   },
   {
     "entry": "vitaraṇa",
@@ -124364,7 +124364,7 @@
     "entry": "samiñjati",
     "grammar": "saṁ + iñjati",
     "definition": "doubles up; moves; wavers",
-    "xr": "çñj or çj to stretc.h"
+    "xr": "çñj or çj to stretch"
   },
   {
     "entry": "samita",
@@ -125772,24 +125772,24 @@
   {
     "entry": "sampasārita",
     "grammar": "past participle",
-    "definition": "spread; stretc.hed out",
+    "definition": "spread; stretched out",
     "xr": "sampasāreti"
   },
   {
     "entry": "sampasāreti",
     "grammar": "saṁ + pa + sar + e",
-    "definition": "spreads; stretc.hes out"
+    "definition": "spreads; stretches out"
   },
   {
     "entry": "sampasāretvā",
     "grammar": "absolutive",
-    "definition": "having spread; having stretc.hed out",
+    "definition": "having spread; having stretched out",
     "xr": "sampasāreti"
   },
   {
     "entry": "sampasāresi",
     "grammar": "aorist",
-    "definition": "spread; stretc.hed out",
+    "definition": "spread; stretched out",
     "xr": "sampasāreti"
   },
   {
@@ -133395,7 +133395,7 @@
   {
     "entry": "hatthapasāraṇa",
     "grammar": "neuter",
-    "definition": "stretc.hing out one’s hand"
+    "definition": "stretching out one’s hand"
   },
   {
     "entry": "hatthapāsa",


### PR DESCRIPTION
Fixes extra dots in words like "stretc.hes" in the NCPED.

Used the regex `(?<=\w{2,})\.(?=\w)`. There are a few more matches but I'm not sure if and how to fix them.