### PR TITLE
fix links to point to download page (used to point to cover page)

### DIFF
--- a/html_text/en/pli/sutta/dn/dn1.html
+++ b/html_text/en/pli/sutta/dn/dn1.html
@@ -498,7 +498,7 @@
 P.O. Box. 61<br>
 54, Sangharaja Mawatha<br>
 Kandy, Sri Lanka</address>
-<p>Complete book available from <a href='http://www.bps.lk/cover.php?id=bp209s'>Buddhist Publication Society</a>.</p>
+<p>Complete book available from <a href='https://www.bps.lk/library-search-select.php?id=bp209s'>Buddhist Publication Society</a>.</p>
 <p>Prepared for SuttaCentral by <span class='editor'>Bhikkhu Sujato</span>.</p>
 </footer>
 </article>

--- a/html_text/en/pli/sutta/dn/dn15.html
+++ b/html_text/en/pli/sutta/dn/dn15.html
@@ -176,7 +176,7 @@
 P.O. Box. 61<br>
 54, Sangharaja Mawatha<br>
 Kandy, Sri Lanka</address>
-<p>Complete book available from <a href='http://www.bps.lk/cover.php?id=bp211s'>Buddhist Publication Society</a>.</p>
+<p>Complete book available from <a href='https://www.bps.lk/library-search-select.php?id=bp211s'>Buddhist Publication Society</a>.</p>
 <p>Prepared for SuttaCentral by <span class='editor'>Bhikkhu Sujato</span>.</p>
 </footer>
 </article>

--- a/html_text/en/pli/sutta/dn/dn2.html
+++ b/html_text/en/pli/sutta/dn/dn2.html
@@ -445,7 +445,7 @@
 P.O. Box. 61<br>
 54, Sangharaja Mawatha<br>
 Kandy, Sri Lanka</address>
-<p>Complete book available from <a href='https://www.bps.lk/cover.php?id=bp212s'>Buddhist Publication Society</a>.</p>
+<p>Complete book available from <a href='https://www.bps.lk/library-search-select.php?id=bp212s'>Buddhist Publication Society</a>.</p>
 <p>Prepared for SuttaCentral by <span class='editor'>Bhikkhu Sujato</span>.</p>
 </footer>
 </article>


### PR DESCRIPTION
Links to source pdf used to point to the cover pdf with no link to the full text pdf. Changed the links to point to the books' reference pages which have links to full text download. https://discourse.suttacentral.net/t/suboptimal-external-links-to-bps/31851