### PR TITLE
AN Indonesian Translation Subchapter Adjustment

### DIFF
--- a/html_text/id/pli/sutta/an/an1/an1.188-197.html
+++ b/html_text/id/pli/sutta/an/an1/an1.188-197.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>i. Sub Bab Pertama</li>
 </ul>
 <h1>1.188–1.197. (1–10)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.198-208.html
+++ b/html_text/id/pli/sutta/an/an1/an1.198-208.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>ii. Sub Bab Ke Dua</li>
 </ul>
 <h1>1.198–1.208. (1–11)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.209-218.html
+++ b/html_text/id/pli/sutta/an/an1/an1.209-218.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>iii. Sub Bab Ke Tiga</li>
 </ul>
 <h1>1.209–1.218. (1–10)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.219-234.html
+++ b/html_text/id/pli/sutta/an/an1/an1.219-234.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>iv. Sub Bab Ke Empat</li>
 </ul>
 <h1>1.219–1.234. (1–16)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.235-247.html
+++ b/html_text/id/pli/sutta/an/an1/an1.235-247.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>v. Sub Bab Ke Lima</li>
 </ul>
 <h1>1.235–1.247. (1–13)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.248-257.html
+++ b/html_text/id/pli/sutta/an/an1/an1.248-257.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>vi. Sub Bab Ke Enam</li>
 </ul>
 <h1>1.248–1.257. (1–10)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.258-267.html
+++ b/html_text/id/pli/sutta/an/an1/an1.258-267.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xiv. Terkemuka</li>
 <li>vii. Sub Bab Ke Tujuh</li>
 </ul>
 <h1>1.258–1.267. (1–10)</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.287-295.html
+++ b/html_text/id/pli/sutta/an/an1/an1.287-295.html
@@ -26,7 +26,6 @@
 <article id='an1.293-1'>
 <h2>1.293–1.295. (26–28)</h2>
 <p>(293) “Adalah tidak mungkin dan tidak masuk akal, para bhikkhu, bahwa seseorang yang melakukan perbuatan baik melalui jasmani dapat karena hal itu, karena alasan itu, dengan hancurnya jasmani, setelah kematian, terlahir kembali di alam sengsara, di alam tujuan kelahiran yang buruk, di alam rendah, di neraka … (294) … bahwa seseorang yang melakukan perbuatan baik melalui ucapan dapat karena hal itu, karena alasan itu, dengan hancurnya jasmani, setelah kematian, terlahir kembali di alam sengsara, di alam tujuan kelahiran yang buruk, di alam rendah, di neraka … (295) … bahwa seseorang yang melakukan perbuatan baik melalui pikiran dapat karena hal itu, karena alasan itu, dengan hancurnya jasmani, setelah kematian, terlahir kembali di alam sengsara, dalam di alam tujuan kelahiran yang buruk, di alam rendah, di neraka; tidak ada kemungkinan seperti itu. Tetapi adalah mungkin <a class='ref pts-vp-pli' id='pts-vp-pli30' href='#pts-vp-pli30'>PTS vp Pali 30</a> bahwa seseorang yang melakukan <span class='add'>perbuatan baik melalui jasmani … perbuatan baik melalui ucapan …</span> perbuatan baik melalui pikiran dapat karena hal itu, karena alasan itu, dengan hancurnya jasmani, setelah kematian, terlahir kembali di alam tujuan kelahiran yang baik, di alam surga; ada kemungkinan seperti itu.”</p>
-<p>xvi. Satu Hal</p>
 </article>
 <footer>
 <p>Translated by <span class='author'>Indra Anggara</span> for <a href='http://dhammacitta.org/dcpedia/DhammaCitta_Pedia'>Dhamma Citta</a>.</p>

--- a/html_text/id/pli/sutta/an/an1/an1.296-305.html
+++ b/html_text/id/pli/sutta/an/an1/an1.296-305.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xvi. Satu Hal</li>
 <li>i. Sub Bab Pertama</li>
 </ul>
 <h1>1.296–305</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.306-315.html
+++ b/html_text/id/pli/sutta/an/an1/an1.306-315.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xvi. Satu Hal</li>
 <li>ii. Sub Bab Ke Dua</li>
 </ul>
 <h1>1.306–315</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.316-332.html
+++ b/html_text/id/pli/sutta/an/an1/an1.316-332.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xvi. Satu Hal</li>
 <li>iii. Sub Bab Ke Tiga</li>
 </ul>
 <h1>1.316–332</h1>

--- a/html_text/id/pli/sutta/an/an1/an1.333-377.html
+++ b/html_text/id/pli/sutta/an/an1/an1.333-377.html
@@ -11,6 +11,7 @@
 <ul>
 <li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
 <li class='subdivision'>Buku Kelompok Satu</li>
+<li>xvi. Satu Hal</li>
 <li>iv. Rangkaian Pengulangan Jambudīpa <span class='add'>Sub Bab Ke Empat</span></li>
 </ul>
 <h1>1.333–1.377</h1>


### PR DESCRIPTION
I just realized that chapters XIV and XVI have a different structure because they contain sub-sub-chapters.
Note that the .pdf source file is available [here](https://pustaka.dhammacitta.org/ebook/theravada/Anguttara%20Nikaya%20Jilid%201.pdf).
![image](https://github.com/user-attachments/assets/8c0662c5-17fa-4b32-85b7-0e6a06b960d8)
![image](https://github.com/user-attachments/assets/ff27481a-97ef-4f53-983d-0469bc4ae873)

In comparison, the other chapters look like this:
![image](https://github.com/user-attachments/assets/09ca06a4-e7d6-4360-8590-f7f608e07999)

That's why all the AN "division" and "subdivision" labels need to be adjusted. Here's an example for an1.296-305.html:

**Before:**
```html
<li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
<li class='subdivision'>Buku Kelompok Satu</li>
<li>i. Sub Bab Pertama</li>
```

**After:**
```html
<li class='division' lang='pli' translate='no'>Aṅguttara Nikāya</li>
<li class='subdivision'>Buku Kelompok Satu</li>
<li>xvi. Satu Hal</li>
<li>i. Sub Bab Pertama</li>
```