### PR TITLE
fix(map): "Line 18" should be "Pārāyanavagga journey"

### DIFF
--- a/additional-info/map_data.json
+++ b/additional-info/map_data.json
@@ -3639,9 +3639,9 @@
       },
       "properties": {
         "layer": "Pārāyanavagga journey",
-        "name": "Line 18",
+        "name": "Pārāyanavagga journey",
         "style": { "color": "#777777", "opacity": 1, "weight": 3.713 },
-        "id": "line 18"
+        "id": "Pārāyanavagga journey"
       }
     },
     {


### PR DESCRIPTION
## Summary

This item has a name, so it shouldn't be "Line 18"

## Details

- the ambiguous number "Line 18" doesn't match any other data point and is visible on the site/map:
    <details>
      <summary>screenshots:</summary>
      <img width="1496" height="557" alt="Screenshot 2026-07-19 at 1 34 23 PM" src="https://github.com/user-attachments/assets/ad50b3bd-55a2-4bc6-87a8-4611ebabecbf" />
      <img width="375" height="683" alt="Screenshot 2026-07-19 at 1 34 49 PM" src="https://github.com/user-attachments/assets/1327db1c-886a-433c-9f11-9b6e98eb3500" />
    </details>

- the new name, "Pārāyanavagga journey", matches "Mahāparinibbāna journey" a [bit lower down](https://github.com/suttacentral/sc-data/blob/e8eb11d30c5a381bb44d83691ecc89ea7bce425b/additional-info/map_data.json#L3307)
  - this is the "line"s between each coordinate, i.e. the path itself of the journey
  
## References

Saw and root caused this when looking at https://github.com/suttacentral/suttacentral/issues/3679